### PR TITLE
feat: Google I/O 2026 model update (Gemini 3.5 Flash default, GA migration, video/multimodal expansion)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ GOOGLE_CLOUD_LOCATION=global
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-key.json
 
 # Model Configuration
-GEMINI_MODEL=gemini-3-flash-preview
+GEMINI_MODEL=gemini-3.5-flash
 GEMINI_TEMPERATURE=1.0
 GEMINI_MAX_TOKENS=8192
 GEMINI_TOP_P=0.95

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -223,7 +223,7 @@ interface QueryOptions {
 **ImageGenerationOptions**:
 ```typescript
 interface ImageGenerationOptions {
-  model?: string;        // Default: 'gemini-3-pro-image-preview'
+  model?: string;        // Default: 'gemini-3-pro-image'
   aspectRatio?: string;  // e.g., '1:1', '16:9', '1:4'
   imageSize?: string;    // '0.5K' | '1K' | '2K' | '4K'
 }
@@ -594,7 +594,7 @@ Validates the `query` tool input:
 z.object({
   prompt: z.string(),
   sessionId: z.string().optional(),
-  model: z.string().optional(),  // e.g., 'gemini-3-flash-preview', 'gemini-3.1-pro-preview', 'gemini-3.1-flash-lite-preview'
+  model: z.string().optional(),  // e.g., 'gemini-3.5-flash', 'gemini-3.1-pro-preview', 'gemini-3.1-flash-lite'
   thinkingLevel: z.enum(['minimal','low','medium','high']).optional(),
   mediaResolution: z.enum(['low','medium','high']).optional(),
   parts: z.array(MultimodalPartSchema).optional(),
@@ -608,7 +608,7 @@ Validates the `generate_image` tool input:
 ```typescript
 z.object({
   prompt: z.string(),
-  model: z.enum(['gemini-3-pro-image-preview', 'gemini-3.1-flash-image-preview', 'gemini-2.5-flash-image']).optional(),
+  model: z.enum(['gemini-3-pro-image', 'gemini-3.1-flash-image', 'gemini-2.5-flash-image']).optional(),
   aspectRatio: z.enum(['1:1','1:4','1:8','2:3','3:2','3:4','4:1','4:3','4:5','5:4','8:1','9:16','16:9','21:9']).optional(),
   imageSize: z.enum(['0.5K', '1K', '2K', '4K']).optional(),
   imagePaths: z.array(z.string()).max(14).optional(),
@@ -846,7 +846,7 @@ Each runs as separate process with independent:
 - `errors/` folder (SecurityError, ModelBehaviorError)
 - `utils/` folder (Logger, generated file savers, security validators)
 - `handlers/` folder (QueryHandler, SearchHandler, FetchHandler, generation handlers)
-- Gemini 3 model support (`gemini-3-flash-preview` default, `thinkingLevel` API)
+- Gemini 3 model support (`gemini-3.5-flash` default, `thinkingLevel` API)
 - File-output generation tools (`generate_image`, `generate_video`, `check_video`, `generate_speech`, `generate_music`)
 
 **Benefits**:

--- a/GENERATION.md
+++ b/GENERATION.md
@@ -45,7 +45,7 @@ export GEMINI_MUSIC_OUTPUT_DIR="/path/to/music"
 | Parameter | Type | Notes |
 |-----------|------|-------|
 | `prompt` | string | Required |
-| `model` | enum | `gemini-3-pro-image-preview`, `gemini-3.1-flash-image-preview`, `gemini-2.5-flash-image` |
+| `model` | enum | `gemini-3-pro-image`, `gemini-3.1-flash-image`, `gemini-2.5-flash-image` |
 | `aspectRatio` | enum | Includes standard ratios and 3.1 Flash-only wide/tall ratios |
 | `imageSize` | enum | `0.5K`, `1K`, `2K`, `4K`; omit for `gemini-2.5-flash-image` |
 | `imagePaths` | string[] | Optional local reference images, max 14; `gemini-2.5-flash-image` supports at most 3. Supported file types: PNG (`.png`), JPEG (`.jpg`, `.jpeg`), WEBP (`.webp`), HEIC (`.heic`), HEIF (`.heif`) |
@@ -60,7 +60,7 @@ Example:
   "name": "generate_image",
   "arguments": {
     "prompt": "A cinematic product photo of a matte black espresso machine",
-    "model": "gemini-3.1-flash-image-preview",
+    "model": "gemini-3.1-flash-image",
     "aspectRatio": "16:9",
     "imageSize": "2K"
   }

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -88,7 +88,7 @@ The Gemini AI MCP Server is a production-grade intelligent agent that enables AI
 - Speech generation via Gemini TTS models (`generateSpeech`)
 - Music generation via Lyria models (`generateMusic`)
 - Video generation via Veo models (`generateVideo`, `checkVideoOperation`)
-- Supports Gemini 3 models (`gemini-3-flash-preview`, `gemini-3.1-pro-preview`, and later)
+- Supports Gemini 3 models (`gemini-3.5-flash`, `gemini-3.1-pro-preview`, and later)
 
 **Logger.ts** (`src/utils/`)
 - File-based logging (`logs/general.log`, `logs/reasoning.log`)
@@ -220,7 +220,7 @@ User Input → Turn 1..10 Loop:
 - Returns saved file paths
 
 ### 11. Gemini 3 Model Support
-- Full support for `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, and subsequent Gemini 3 models
+- Full support for `gemini-3.5-flash`, `gemini-3.1-pro-preview`, and subsequent Gemini 3 models
 - Automatic model detection for thinking level configuration
 - `mediaResolution` parameter support for multimodal inputs
 

--- a/MULTIMODAL.md
+++ b/MULTIMODAL.md
@@ -384,15 +384,15 @@ const response = await client.callTool({
 
 Multimodal support requires using a Gemini model that supports multimodal inputs. Recommended models:
 
-- `gemini-3-flash-preview` (default, strong multimodal and agentic support)
+- `gemini-3.5-flash` (default, strong multimodal and agentic support)
 - `gemini-3.1-pro-preview` (high-capability reasoning and multimodal support)
-- `gemini-3.1-flash-lite-preview` (cost-efficient multimodal support)
+- `gemini-3.1-flash-lite` (cost-efficient multimodal support)
 - `gemini-2.5-pro` (stable production-ready multimodal support)
 
 Set your model in the environment:
 
 ```bash
-export GEMINI_MODEL="gemini-3-flash-preview"
+export GEMINI_MODEL="gemini-3.5-flash"
 ```
 
 ## File Size Limits
@@ -417,7 +417,7 @@ export GEMINI_MODEL="gemini-3-flash-preview"
 
 3. **Batch Related Queries**: Send multiple related files in one query rather than separate queries
 
-4. **Choose the Right Model**: Use models with multimodal capabilities (e.g., `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`)
+4. **Choose the Right Model**: Use models with multimodal capabilities (e.g., `gemini-3.5-flash`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`)
 
 5. **Validate MIME Types**: Ensure you're using supported MIME types from the list above
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This server provides:
 - **Agentic Loop**: Turn-based execution with automatic tool selection and reasoning
 - **Query Gemini**: Access Gemini models via Vertex AI or Google AI Studio
 - **Multimodal Support**: Send images, audio, video, and code files alongside text prompts
-- **Image Generation**: Generate images using Gemini image models (gemini-3-pro-image-preview, gemini-3.1-flash-image-preview, gemini-2.5-flash-image)
+- **Image Generation**: Generate images using Gemini image models (gemini-3-pro-image, gemini-3.1-flash-image, gemini-2.5-flash-image)
 - **Speech & Music Generation**: Generate TTS audio with Gemini TTS and music with Lyria
 - **Tool Execution**: Built-in WebFetch + integration with external MCP servers
 - **Multi-turn Conversations**: Maintain context across queries with session management
@@ -43,9 +43,9 @@ Inspired by OpenAI Agents SDK, the server operates as an autonomous agent:
 
 ### 🔮 Gemini 3 Model Support
 Full support for Gemini 3 generation models:
-- **gemini-3-flash-preview**: Default model — fast and capable
+- **gemini-3.5-flash**: Default model — fast and capable
 - **gemini-3.1-pro-preview**: High-capability reasoning model
-- **gemini-3.1-flash-lite-preview**: Cost-efficient multimodal model for high-volume workloads
+- **gemini-3.1-flash-lite**: Cost-efficient multimodal model for high-volume workloads
 - **gemini-3.1-pro-preview-customtools**: Agentic endpoint optimized for custom tools
 - **thinkingLevel**: Per-query thinking budget control for Gemini 3 models
 - **GEMINI_MEDIA_RESOLUTION**: Control media quality for multimodal inputs
@@ -56,9 +56,9 @@ Full support for Gemini 3 generation models:
 
 ### 🖼️ Image Generation
 Generate images directly from text prompts using Gemini image models:
-- **gemini-3-pro-image-preview**: Professional asset production with 4K resolution support (default)
-- **gemini-3.1-flash-image-preview**: High-efficiency generation with 0.5K-4K resolution and reference images
-- **gemini-2.5-flash-image**: Fast 1K image generation and editing
+- **gemini-3-pro-image**: Professional asset production with 4K resolution support (default)
+- **gemini-3.1-flash-image**: High-efficiency generation with 0.5K-4K resolution and reference images
+- **gemini-2.5-flash-image**: Fast 1K image generation and editing (retiring 2026-10-02; prefer gemini-3.1-flash-image)
 - Configurable aspect ratios: 1:1, 16:9, 9:16, 4:3, and more
 - Images automatically saved to configurable output directory
 
@@ -149,7 +149,7 @@ export GOOGLE_GENAI_USE_VERTEXAI="false"
 
 **Optional Model Settings:**
 ```bash
-export GEMINI_MODEL="gemini-3-flash-preview"  # Default model
+export GEMINI_MODEL="gemini-3.5-flash"  # Default model
 export GEMINI_TEMPERATURE="1.0"
 export GEMINI_MAX_TOKENS="8192"
 export GEMINI_TOP_P="0.95"
@@ -219,7 +219,7 @@ Add to your MCP client configuration:
       "env": {
         "GOOGLE_CLOUD_PROJECT": "your-gcp-project-id",
         "GOOGLE_CLOUD_LOCATION": "us-central1",
-        "GEMINI_MODEL": "gemini-3-flash-preview",
+        "GEMINI_MODEL": "gemini-3.5-flash",
         "GEMINI_ENABLE_CONVERSATIONS": "true"
       }
     }
@@ -237,7 +237,7 @@ Add to your MCP client configuration:
       "env": {
         "GOOGLE_CLOUD_PROJECT": "your-gcp-project-id",
         "GOOGLE_CLOUD_LOCATION": "us-central1",
-        "GEMINI_MODEL": "gemini-3-flash-preview"
+        "GEMINI_MODEL": "gemini-3.5-flash"
       }
     }
   }
@@ -295,7 +295,7 @@ Main agentic entrypoint that handles multi-turn execution with automatic tool se
 **Parameters:**
 - `prompt` (string, required): The text prompt to send
 - `sessionId` (string, optional): Conversation session ID
-- `model` (string, optional): Model override (e.g., `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3.1-pro-preview-customtools`)
+- `model` (string, optional): Model override (e.g., `gemini-3.5-flash`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`, `gemini-3.1-pro-preview-customtools`)
 - `thinkingLevel` (string, optional): Gemini 3 thinking level. Options: `minimal`, `low`, `medium`, `high`
 - `mediaResolution` (string, optional): Global media resolution for multimodal inputs. Options: `low`, `medium`, `high`
 - `parts` (array, optional): Multimodal content parts (images, audio, video, documents)
@@ -369,11 +369,11 @@ Generate images from text prompts using Gemini image models.
 **Parameters:**
 - `prompt` (string, required): Image generation prompt describing what to generate
 - `model` (string, optional): Image model to use. Options:
-  - `gemini-3-pro-image-preview` (default) — professional quality, supports up to 4K resolution
-  - `gemini-3.1-flash-image-preview` — high-efficiency with 0.5K-4K and reference image support
-  - `gemini-2.5-flash-image` — fast 1K image generation and editing
-- `aspectRatio` (string, optional): Image aspect ratio. Default: `1:1`. Options: `1:1`, `1:4`, `1:8`, `2:3`, `3:2`, `3:4`, `4:1`, `4:3`, `4:5`, `5:4`, `8:1`, `9:16`, `16:9`, `21:9` (`1:4`, `1:8`, `4:1`, `8:1` require `gemini-3.1-flash-image-preview`)
-- `imageSize` (string, optional): Output resolution. Default: `1K`. Options: `0.5K`, `1K`, `2K`, `4K` (`0.5K` requires `gemini-3.1-flash-image-preview`; omit for `gemini-2.5-flash-image`)
+  - `gemini-3-pro-image` (default) — professional quality, supports up to 4K resolution
+  - `gemini-3.1-flash-image` — high-efficiency with 0.5K-4K and reference image support
+  - `gemini-2.5-flash-image` — fast 1K image generation and editing (retiring 2026-10-02; prefer gemini-3.1-flash-image)
+- `aspectRatio` (string, optional): Image aspect ratio. Default: `1:1`. Options: `1:1`, `1:4`, `1:8`, `2:3`, `3:2`, `3:4`, `4:1`, `4:3`, `4:5`, `5:4`, `8:1`, `9:16`, `16:9`, `21:9` (`1:4`, `1:8`, `4:1`, `8:1` require `gemini-3.1-flash-image`)
+- `imageSize` (string, optional): Output resolution. Default: `1K`. Options: `0.5K`, `1K`, `2K`, `4K` (`0.5K` requires `gemini-3.1-flash-image`; omit for `gemini-2.5-flash-image`)
 - `imagePaths` (array, optional): Local reference images for editing or style transfer (max 14; `gemini-2.5-flash-image` supports at most 3). Supported file types: PNG (`.png`), JPEG (`.jpg`, `.jpeg`), WEBP (`.webp`), HEIC (`.heic`), HEIF (`.heif`)
 - `systemInstruction` (string, optional): System instruction for Gemini 3 image models
 - `thinkingLevel` (string, optional): Gemini 3.1 Flash Image thinking level: `minimal` or `high`
@@ -390,7 +390,7 @@ generate_image: "A serene mountain landscape at sunset"
 
 # Generate a wide-format image with Nano Banana 2 at 4K
 generate_image: "Futuristic cityscape at night"
-model: "gemini-3.1-flash-image-preview"
+model: "gemini-3.1-flash-image"
 aspectRatio: "16:9"
 imageSize: "4K"
 ```

--- a/examples/image-generation.md
+++ b/examples/image-generation.md
@@ -44,16 +44,16 @@ Three image generation models are available:
 
 | Model | Description |
 |-------|-------------|
-| `gemini-3-pro-image-preview` | Default. Professional asset production, supports up to 4K resolution |
-| `gemini-3.1-flash-image-preview` | High-efficiency with 0.5K-4K, reference images, and new aspect ratios |
-| `gemini-2.5-flash-image` | Fast 1K image generation and editing |
+| `gemini-3-pro-image` | Default. Professional asset production, supports up to 4K resolution |
+| `gemini-3.1-flash-image` | High-efficiency with 0.5K-4K, reference images, and new aspect ratios |
+| `gemini-2.5-flash-image` | Fast 1K image generation and editing (retiring 2026-10-02; prefer gemini-3.1-flash-image) |
 
 ```typescript
 const request = {
   name: "generate_image",
   arguments: {
     prompt: "A photorealistic portrait of a red fox in a forest",
-    model: "gemini-3.1-flash-image-preview"
+    model: "gemini-3.1-flash-image"
   }
 };
 ```
@@ -79,16 +79,16 @@ Control the image dimensions with the `aspectRatio` parameter. Defaults to `1:1`
 | Value | Use Case |
 |-------|----------|
 | `1:1` | Square (default), social media posts |
-| `1:4` | Tall banner (requires `gemini-3.1-flash-image-preview`) |
-| `1:8` | Extra-tall strip (requires `gemini-3.1-flash-image-preview`) |
+| `1:4` | Tall banner (requires `gemini-3.1-flash-image`) |
+| `1:8` | Extra-tall strip (requires `gemini-3.1-flash-image`) |
 | `2:3` | Portrait, mobile wallpaper |
 | `3:2` | Landscape, photography standard |
 | `3:4` | Portrait, tablet screen |
-| `4:1` | Wide banner (requires `gemini-3.1-flash-image-preview`) |
+| `4:1` | Wide banner (requires `gemini-3.1-flash-image`) |
 | `4:3` | Landscape, classic photo |
 | `4:5` | Portrait, Instagram |
 | `5:4` | Landscape |
-| `8:1` | Extra-wide strip (requires `gemini-3.1-flash-image-preview`) |
+| `8:1` | Extra-wide strip (requires `gemini-3.1-flash-image`) |
 | `9:16` | Portrait, mobile/story |
 | `16:9` | Widescreen, desktop wallpaper |
 | `21:9` | Ultrawide, cinematic |
@@ -109,17 +109,17 @@ The `imageSize` parameter sets the output resolution. Defaults to `1K`.
 
 | Value | Resolution | Supported Models |
 |-------|------------|-----------------|
-| `0.5K` | ~512px | `gemini-3.1-flash-image-preview` |
-| `1K` | ~1024px (default) | `gemini-3-pro-image-preview`, `gemini-3.1-flash-image-preview`; omit `imageSize` for `gemini-2.5-flash-image` |
-| `2K` | ~2048px | `gemini-3-pro-image-preview`, `gemini-3.1-flash-image-preview` |
-| `4K` | ~4096px | `gemini-3-pro-image-preview` or `gemini-3.1-flash-image-preview` |
+| `0.5K` | ~512px | `gemini-3.1-flash-image` |
+| `1K` | ~1024px (default) | `gemini-3-pro-image`, `gemini-3.1-flash-image`; omit `imageSize` for `gemini-2.5-flash-image` |
+| `2K` | ~2048px | `gemini-3-pro-image`, `gemini-3.1-flash-image` |
+| `4K` | ~4096px | `gemini-3-pro-image` or `gemini-3.1-flash-image` |
 
 ```typescript
 const request = {
   name: "generate_image",
   arguments: {
     prompt: "Ultra-detailed macro photograph of a butterfly wing",
-    model: "gemini-3.1-flash-image-preview",
+    model: "gemini-3.1-flash-image",
     imageSize: "4K"
   }
 };
@@ -132,7 +132,7 @@ const request = {
   name: "generate_image",
   arguments: {
     prompt: "A dramatic oil painting of a Viking longship on stormy seas, massive waves, lightning in the background, cinematic composition",
-    model: "gemini-3-pro-image-preview",
+    model: "gemini-3-pro-image",
     aspectRatio: "21:9",
     imageSize: "4K"
   }
@@ -183,4 +183,4 @@ export GEMINI_IMAGE_OUTPUT_DIR="/path/to/output/directory"
 1. **Be specific** - Include style, lighting, mood, and composition details
 2. **Use artistic references** - "in the style of impressionism", "cinematic lighting", "golden hour"
 3. **Specify what to avoid** - Some models support negative prompts in the main prompt field
-4. **For 4K results** - Use `gemini-3-pro-image-preview` or `gemini-3.1-flash-image-preview` with `imageSize: "4K"`; prompts with fine detail benefit most from higher resolution
+4. **For 4K results** - Use `gemini-3-pro-image` or `gemini-3.1-flash-image` with `imageSize: "4K"`; prompts with fine detail benefit most from higher resolution

--- a/examples/multimodal-usage.md
+++ b/examples/multimodal-usage.md
@@ -253,11 +253,11 @@ If you're testing with the MCP Inspector, you can send multimodal content like t
 ## Model Recommendations
 
 For best multimodal performance, use:
-- `gemini-3-flash-preview` - Default with strong multimodal support
+- `gemini-3.5-flash` - Default with strong multimodal support
 - `gemini-3.1-pro-preview` - High-capability reasoning with strong multimodal support
-- `gemini-3.1-flash-lite-preview` - Cost-efficient multimodal support
+- `gemini-3.1-flash-lite` - Cost-efficient multimodal support
 
 Set in your environment:
 ```bash
-export GEMINI_MODEL="gemini-3-flash-preview"
+export GEMINI_MODEL="gemini-3.5-flash"
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@google/genai": "^1.43.0",
+        "@google/genai": "^2.8.0",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "dotenv": "^17.3.1",
         "zod": "^4.3.6"
@@ -466,9 +466,10 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.43.0.tgz",
-      "integrity": "sha512-hklCsJNdMlDM1IwcCVcGQFBg2izY0+t5BIGbRsxi2UnKi6AGKL7pqJqmBDNRbw0bYCs4y3NA7TB+fkKfP/Nrdw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.8.0.tgz",
+      "integrity": "sha512-pc2ayxqO5+O7AvnHBqpNHIk7PAZkHZgL31tbyx0gJZBSS9qPYiQoqwK7oYOw/ePmG6QY4EMSu+304vD5QlhXAw==",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^10.3.0",
@@ -505,7 +506,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
       "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -1041,7 +1041,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1383,7 +1382,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.1.tgz",
       "integrity": "sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2166,7 +2164,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:mcp": "npx @modelcontextprotocol/inspector node build/index.js",
     "test:list": "echo '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\",\"params\":{}}' | node build/index.js",
     "test:query": "echo '{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"query\",\"arguments\":{\"prompt\":\"Hello\"}}}' | node build/index.js 2>&1",
-    "test:env": "node -e 'console.log(\"Project:\", process.env.GOOGLE_CLOUD_PROJECT); console.log(\"Location:\", process.env.GOOGLE_CLOUD_LOCATION); console.log(\"Model:\", process.env.GEMINI_MODEL || \"gemini-3-flash-preview\")'"
+    "test:env": "node -e 'console.log(\"Project:\", process.env.GOOGLE_CLOUD_PROJECT); console.log(\"Location:\", process.env.GOOGLE_CLOUD_LOCATION); console.log(\"Model:\", process.env.GEMINI_MODEL || \"gemini-3.5-flash\")'"
   },
   "keywords": [
     "mcp",
@@ -37,7 +37,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@google/genai": "^1.43.0",
+    "@google/genai": "^2.8.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "dotenv": "^17.3.1",
     "zod": "^4.3.6"

--- a/src/agentic/AgenticLoop.ts
+++ b/src/agentic/AgenticLoop.ts
@@ -77,6 +77,7 @@ export class AgenticLoop {
           model: options.model,
           thinkingLevel: options.thinkingLevel,
           mediaResolution: options.mediaResolution,
+          backend: options.backend,
         },
         isFirstTurn ? multimodalParts : undefined
       );
@@ -128,6 +129,7 @@ export class AgenticLoop {
             model: options.model,
             thinkingLevel: options.thinkingLevel,
             mediaResolution: options.mediaResolution,
+            backend: options.backend,
           });
 
           // Add fallback response as final output

--- a/src/agentic/RunState.ts
+++ b/src/agentic/RunState.ts
@@ -38,6 +38,7 @@ export interface RunOptions {
   model?: string;
   thinkingLevel?: string;
   mediaResolution?: string;
+  backend?: 'vertex' | 'ai-studio';
 }
 
 export class RunState {

--- a/src/agentic/RunState.ts
+++ b/src/agentic/RunState.ts
@@ -5,6 +5,7 @@
 
 import { Logger } from '../utils/Logger.js';
 import { Message } from '../types/index.js';
+import { Backend } from '../types/config.js';
 
 export interface RunItem {
   type: 'message' | 'tool_call' | 'tool_result' | 'reasoning';
@@ -38,7 +39,7 @@ export interface RunOptions {
   model?: string;
   thinkingLevel?: string;
   mediaResolution?: string;
-  backend?: 'vertex' | 'ai-studio';
+  backend?: Backend;
 }
 
 export class RunState {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,29 +4,61 @@
  * Reference: https://googleapis.github.io/js-genai/release_docs/index.html
  */
 
-import { GeminiAIConfig } from '../types/index.js';
+import { GeminiAIConfig, Backend } from '../types/index.js';
 
 export function loadConfig(): GeminiAIConfig {
   const apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY;
   const projectId = process.env.GOOGLE_CLOUD_PROJECT;
   const explicitVertexMode = process.env.GOOGLE_GENAI_USE_VERTEXAI;
-  const useVertexAI = explicitVertexMode === undefined
-    ? Boolean(projectId) || !apiKey
-    : explicitVertexMode === "true";
 
-  if (useVertexAI && !projectId) {
+  // Detect which backends have credentials. When both are present, the server
+  // can route per request (the `backend` tool argument); otherwise it serves
+  // the single available backend.
+  const vertexAvailable = Boolean(projectId);
+  const aiStudioAvailable = Boolean(apiKey);
+
+  if (!vertexAvailable && !aiStudioAvailable) {
     console.error(
-      "Error: GOOGLE_CLOUD_PROJECT environment variable is required when using Vertex AI mode"
+      "Error: set GOOGLE_CLOUD_PROJECT (Vertex AI) and/or GEMINI_API_KEY/GOOGLE_API_KEY (Google AI Studio)."
     );
     process.exit(1);
   }
 
-  if (!useVertexAI && !apiKey) {
+  // Resolve the default backend: explicit override wins, else infer from creds
+  // (Vertex preferred when a project is set, matching prior behavior).
+  let defaultBackend: Backend;
+  if (explicitVertexMode === "true") {
+    defaultBackend = "vertex";
+  } else if (explicitVertexMode === "false") {
+    defaultBackend = "ai-studio";
+  } else {
+    defaultBackend = vertexAvailable ? "vertex" : "ai-studio";
+  }
+
+  if (defaultBackend === "vertex" && !vertexAvailable) {
     console.error(
-      "Error: GEMINI_API_KEY or GOOGLE_API_KEY environment variable is required when using Google AI Studio / Gemini Developer API mode"
+      "Error: GOOGLE_CLOUD_PROJECT is required when GOOGLE_GENAI_USE_VERTEXAI=true (Vertex AI mode)"
     );
     process.exit(1);
   }
+  if (defaultBackend === "ai-studio" && !aiStudioAvailable) {
+    console.error(
+      "Error: GEMINI_API_KEY or GOOGLE_API_KEY is required when GOOGLE_GENAI_USE_VERTEXAI=false (Google AI Studio mode)"
+    );
+    process.exit(1);
+  }
+
+  // Default backend first so it is the natural primary in any ordered use.
+  const availableBackends: Backend[] = [];
+  if (defaultBackend === "vertex") {
+    availableBackends.push("vertex");
+    if (aiStudioAvailable) availableBackends.push("ai-studio");
+  } else {
+    availableBackends.push("ai-studio");
+    if (vertexAvailable) availableBackends.push("vertex");
+  }
+
+  const useVertexAI = defaultBackend === "vertex";
 
   // Get location - follows gen-ai SDK standards
   // Note: @google/genai with Vertex AI mode requires location for proper authentication
@@ -78,6 +110,8 @@ export function loadConfig(): GeminiAIConfig {
     location,
     apiKey,
     useVertexAI,
+    defaultBackend,
+    availableBackends,
     model,
     temperature,
     maxTokens,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -33,7 +33,7 @@ export function loadConfig(): GeminiAIConfig {
   const location = process.env.GOOGLE_CLOUD_LOCATION || "global";
 
   // Model and parameters - use GEMINI_* environment variables
-  const model = process.env.GEMINI_MODEL || "gemini-3-flash-preview";
+  const model = process.env.GEMINI_MODEL || "gemini-3.5-flash";
   const temperature = parseFloat(process.env.GEMINI_TEMPERATURE || "1.0");
   const maxTokens = parseInt(process.env.GEMINI_MAX_TOKENS || "8192", 10);
   const topP = parseFloat(process.env.GEMINI_TOP_P || "0.95");

--- a/src/handlers/ImageGenerationHandler.ts
+++ b/src/handlers/ImageGenerationHandler.ts
@@ -25,6 +25,7 @@ export class ImageGenerationHandler {
       systemInstruction: input.systemInstruction,
       thinkingLevel: input.thinkingLevel,
       mediaResolution: input.mediaResolution,
+      backend: input.backend,
     });
 
     if (result.images.length === 0) {

--- a/src/handlers/MusicGenerationHandler.ts
+++ b/src/handlers/MusicGenerationHandler.ts
@@ -32,6 +32,7 @@ export class MusicGenerationHandler {
       durationSeconds: input.durationSeconds,
       bpm: input.bpm,
       intensity: input.intensity,
+      backend: input.backend,
     });
 
     if (result.audios.length === 0) {

--- a/src/handlers/QueryHandler.ts
+++ b/src/handlers/QueryHandler.ts
@@ -60,6 +60,7 @@ export class QueryHandler {
           model: input.model,
           thinkingLevel: input.thinkingLevel,
           mediaResolution: input.mediaResolution,
+          backend: input.backend,
         },
         input.parts // Pass multimodal parts
       );

--- a/src/handlers/SpeechGenerationHandler.ts
+++ b/src/handlers/SpeechGenerationHandler.ts
@@ -28,6 +28,7 @@ export class SpeechGenerationHandler {
       voiceName: input.voiceName,
       languageCode: input.languageCode,
       speakers: input.speakers,
+      backend: input.backend,
     });
 
     if (result.audios.length === 0) {

--- a/src/handlers/VideoGenerationHandler.forwarding.test.ts
+++ b/src/handlers/VideoGenerationHandler.forwarding.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { VideoGenerationHandler } from './VideoGenerationHandler.js';
+
+/**
+ * Regression test: the handler must forward every parsed option to the
+ * service. compressionQuality/resizeMode were initially dropped here, so the
+ * tool advertised them while the service silently used defaults.
+ */
+describe('VideoGenerationHandler option forwarding', () => {
+  function createHandler() {
+    const generateVideo = vi.fn().mockResolvedValue({ operationId: 'op-1' });
+    const handler = new VideoGenerationHandler(
+      { generateVideo } as any,
+      { videoOutputDir: '/tmp/videos' } as any
+    );
+    return { handler, generateVideo };
+  }
+
+  it('forwards compressionQuality and resizeMode to generateVideo', async () => {
+    const { handler, generateVideo } = createHandler();
+
+    await handler.handle({
+      prompt: 'animate this frame',
+      imagePath: '/tmp/frame.png',
+      compressionQuality: 'lossless',
+      resizeMode: 'crop',
+    } as any);
+
+    expect(generateVideo).toHaveBeenCalledTimes(1);
+    const [prompt, options] = generateVideo.mock.calls[0];
+    expect(prompt).toBe('animate this frame');
+    expect(options.compressionQuality).toBe('lossless');
+    expect(options.resizeMode).toBe('crop');
+    expect(options.imagePath).toBe('/tmp/frame.png');
+  });
+
+  it('leaves the new fields undefined when not provided', async () => {
+    const { handler, generateVideo } = createHandler();
+
+    await handler.handle({ prompt: 'a dancing cat' } as any);
+
+    const [, options] = generateVideo.mock.calls[0];
+    expect(options.compressionQuality).toBeUndefined();
+    expect(options.resizeMode).toBeUndefined();
+  });
+});

--- a/src/handlers/VideoGenerationHandler.test.ts
+++ b/src/handlers/VideoGenerationHandler.test.ts
@@ -235,6 +235,20 @@ describe('GeminiAIMCPServer generate_video wiring', () => {
     expect(mockVideoGenHandle).toHaveBeenCalledWith({ prompt: 'a dancing cat' });
   });
 
+  it('strips the backend argument in single-backend deployments', async () => {
+    // createTestConfig is Vertex-only (useVertexAI: true, no availableBackends).
+    // A backend arg is not advertised and must be ignored, so the request still
+    // parses (it is not rejected by the Vertex-only model/backend enum).
+    await callHandler({
+      params: {
+        name: 'generate_video',
+        arguments: { prompt: 'a dancing cat', backend: 'ai-studio' },
+      },
+    });
+
+    expect(mockVideoGenHandle).toHaveBeenCalledWith({ prompt: 'a dancing cat' });
+  });
+
   it('validates generate_video calls against Gemini Developer API mode', async () => {
     const aiStudioServer = new GeminiAIMCPServer(createTestConfig({ useVertexAI: false }));
     const handlers = getHandlers((aiStudioServer as any).server);

--- a/src/handlers/VideoGenerationHandler.ts
+++ b/src/handlers/VideoGenerationHandler.ts
@@ -34,6 +34,7 @@ export class VideoGenerationHandler {
       videoPath: input.videoPath,
       compressionQuality: input.compressionQuality,
       resizeMode: input.resizeMode,
+      backend: input.backend,
     });
 
     return {

--- a/src/handlers/VideoGenerationHandler.ts
+++ b/src/handlers/VideoGenerationHandler.ts
@@ -32,6 +32,8 @@ export class VideoGenerationHandler {
       lastFramePath: input.lastFramePath,
       referenceImagePaths: input.referenceImagePaths,
       videoPath: input.videoPath,
+      compressionQuality: input.compressionQuality,
+      resizeMode: input.resizeMode,
     });
 
     return {

--- a/src/schemas/index.test.ts
+++ b/src/schemas/index.test.ts
@@ -247,13 +247,13 @@ describe('VideoGenerationSchema Vertex-only output controls', () => {
     expect(() => GeminiApiVideoSchema.parse({
       prompt: 'compressed video',
       compressionQuality: 'lossless',
-    })).toThrow(/compressionQuality is only supported in Vertex AI mode/);
+    })).toThrow(/compressionQuality is only supported by the Vertex AI backend/);
 
     expect(() => GeminiApiVideoSchema.parse({
       prompt: 'animate this frame',
       imagePath: '/tmp/frame.png',
       resizeMode: 'crop',
-    })).toThrow(/resizeMode is only supported in Vertex AI mode/);
+    })).toThrow(/resizeMode is only supported by the Vertex AI backend/);
   });
 });
 
@@ -316,6 +316,53 @@ describe('VideoGenerationSchema Gemini Developer API compatibility', () => {
       imagePath: '/tmp/frame.png',
       personGeneration: 'allow_all',
     })).toThrow(/allow_adult/);
+  });
+});
+
+describe('buildVideoGenerationSchema dual-backend mode', () => {
+  const DualSchema = buildVideoGenerationSchema(true, ['vertex', 'ai-studio']);
+
+  it('accepts both Vertex (-001) and AI Studio (-preview) models when routed correctly', () => {
+    expect(DualSchema.parse({ prompt: 'x', model: 'veo-3.1-generate-001' }).model)
+      .toBe('veo-3.1-generate-001');
+    expect(DualSchema.parse({ prompt: 'x', backend: 'ai-studio', model: 'veo-3.1-generate-preview' }).model)
+      .toBe('veo-3.1-generate-preview');
+  });
+
+  it('rejects a model that does not match the selected backend', () => {
+    // default backend is vertex; a -preview model belongs to ai-studio
+    expect(() => DualSchema.parse({ prompt: 'x', model: 'veo-3.1-generate-preview' }))
+      .toThrow(/does not match the selected backend/);
+    expect(() => DualSchema.parse({ prompt: 'x', backend: 'vertex', model: 'veo-3.1-generate-preview' }))
+      .toThrow(/does not match the selected backend/);
+  });
+
+  it('gates Vertex-only fields by the selected backend', () => {
+    expect(() => DualSchema.parse({
+      prompt: 'x', backend: 'ai-studio', model: 'veo-3.1-generate-preview', seed: 1,
+    })).toThrow(/seed/);
+    // vertex is the default backend, so seed is allowed without a backend arg
+    expect(DualSchema.parse({ prompt: 'x', seed: 1 }).seed).toBe(1);
+  });
+
+  it('rejects a backend value that is not configured', () => {
+    const VertexOnly = buildVideoGenerationSchema(true, ['vertex']);
+    expect(() => VertexOnly.parse({ prompt: 'x', backend: 'ai-studio' })).toThrow();
+  });
+});
+
+describe('buildMusicGenerationSchema dual-backend mode', () => {
+  const DualMusic = buildMusicGenerationSchema(true, ['vertex', 'ai-studio']);
+
+  it('allows WAV only on the ai-studio backend for lyria-3-pro-preview', () => {
+    expect(DualMusic.parse({
+      prompt: 'song', backend: 'ai-studio', model: 'lyria-3-pro-preview', outputMimeType: 'audio/wav',
+    }).outputMimeType).toBe('audio/wav');
+
+    // vertex backend rejects wav
+    expect(() => DualMusic.parse({
+      prompt: 'song', backend: 'vertex', model: 'lyria-3-pro-preview', outputMimeType: 'audio/wav',
+    })).toThrow(/audio\/mp3/);
   });
 });
 

--- a/src/schemas/index.test.ts
+++ b/src/schemas/index.test.ts
@@ -13,12 +13,12 @@ describe('QuerySchema model controls', () => {
   it('accepts Gemini 3.1 Flash-Lite and request-level controls', () => {
     const parsed = QuerySchema.parse({
       prompt: 'Summarize this image',
-      model: 'gemini-3.1-flash-lite-preview',
+      model: 'gemini-3.1-flash-lite',
       thinkingLevel: 'medium',
       mediaResolution: 'high',
     });
 
-    expect(parsed.model).toBe('gemini-3.1-flash-lite-preview');
+    expect(parsed.model).toBe('gemini-3.1-flash-lite');
     expect(parsed.thinkingLevel).toBe('medium');
     expect(parsed.mediaResolution).toBe('high');
   });
@@ -28,7 +28,7 @@ describe('ImageGenerationSchema model compatibility', () => {
   it('accepts Nano Banana 2 specific image options', () => {
     const parsed = ImageGenerationSchema.parse({
       prompt: 'wide product banner',
-      model: 'gemini-3.1-flash-image-preview',
+      model: 'gemini-3.1-flash-image',
       aspectRatio: '8:1',
       imageSize: '0.5K',
       thinkingLevel: 'high',
@@ -45,7 +45,7 @@ describe('ImageGenerationSchema model compatibility', () => {
     expect(() => ImageGenerationSchema.parse({
       prompt: 'wide product banner',
       aspectRatio: '8:1',
-    })).toThrow(/gemini-3\.1-flash-image-preview/);
+    })).toThrow(/gemini-3\.1-flash-image/);
   });
 
   it('rejects imageSize for gemini-2.5-flash-image', () => {
@@ -75,7 +75,7 @@ describe('ImageGenerationSchema model compatibility', () => {
 
     expect(() => ImageGenerationSchema.parse({
       prompt: 'flash image',
-      model: 'gemini-3.1-flash-image-preview',
+      model: 'gemini-3.1-flash-image',
       thinkingLevel: 'medium',
     })).toThrow();
 
@@ -84,25 +84,25 @@ describe('ImageGenerationSchema model compatibility', () => {
       prompt: 'fast image',
       model: 'gemini-2.5-flash-image',
       thinkingLevel: 'high',
-    })).toThrow(/gemini-3\.1-flash-image-preview/);
+    })).toThrow(/gemini-3\.1-flash-image/);
 
-    // gemini-3-pro-image-preview (default) also rejects thinkingLevel — Vertex API does not support it
+    // gemini-3-pro-image (default) also rejects thinkingLevel — Vertex API does not support it
     expect(() => ImageGenerationSchema.parse({
       prompt: 'pro image',
-      model: 'gemini-3-pro-image-preview',
+      model: 'gemini-3-pro-image',
       thinkingLevel: 'high',
-    })).toThrow(/gemini-3\.1-flash-image-preview/);
+    })).toThrow(/gemini-3\.1-flash-image/);
 
-    // Default (no model) also rejects thinkingLevel — default resolves to gemini-3-pro-image-preview server-side
+    // Default (no model) also rejects thinkingLevel — default resolves to gemini-3-pro-image server-side
     expect(() => ImageGenerationSchema.parse({
       prompt: 'default image',
       thinkingLevel: 'high',
-    })).toThrow(/gemini-3\.1-flash-image-preview/);
+    })).toThrow(/gemini-3\.1-flash-image/);
 
-    // Only gemini-3.1-flash-image-preview accepts thinkingLevel
+    // Only gemini-3.1-flash-image accepts thinkingLevel
     expect(ImageGenerationSchema.parse({
       prompt: 'flash image',
-      model: 'gemini-3.1-flash-image-preview',
+      model: 'gemini-3.1-flash-image',
       thinkingLevel: 'high',
     }).thinkingLevel).toBe('high');
   });
@@ -209,6 +209,51 @@ describe('VideoGenerationSchema current Veo models', () => {
       prompt: 'extend this shot',
       videoPath: '/tmp/source.mov',
     })).toThrow(/Unsupported video extension source file type/);
+  });
+});
+
+describe('VideoGenerationSchema Vertex-only output controls', () => {
+  it('accepts compressionQuality and resizeMode for image-to-video in Vertex mode', () => {
+    const parsed = VideoGenerationSchema.parse({
+      prompt: 'animate this frame',
+      imagePath: '/tmp/frame.png',
+      compressionQuality: 'lossless',
+      resizeMode: 'crop',
+    });
+
+    expect(parsed.compressionQuality).toBe('lossless');
+    expect(parsed.resizeMode).toBe('crop');
+  });
+
+  it('rejects resizeMode without imagePath', () => {
+    expect(() => VideoGenerationSchema.parse({
+      prompt: 'text to video',
+      resizeMode: 'pad',
+    })).toThrow(/resizeMode requires imagePath/);
+  });
+
+  it('rejects resizeMode combined with referenceImagePaths', () => {
+    expect(() => VideoGenerationSchema.parse({
+      prompt: 'reference guided',
+      imagePath: '/tmp/frame.png',
+      referenceImagePaths: ['/tmp/ref.png'],
+      resizeMode: 'crop',
+    })).toThrow();
+  });
+
+  it('rejects compressionQuality and resizeMode in Gemini Developer API mode', () => {
+    const GeminiApiVideoSchema = buildVideoGenerationSchema(false);
+
+    expect(() => GeminiApiVideoSchema.parse({
+      prompt: 'compressed video',
+      compressionQuality: 'lossless',
+    })).toThrow(/compressionQuality is only supported in Vertex AI mode/);
+
+    expect(() => GeminiApiVideoSchema.parse({
+      prompt: 'animate this frame',
+      imagePath: '/tmp/frame.png',
+      resizeMode: 'crop',
+    })).toThrow(/resizeMode is only supported in Vertex AI mode/);
   });
 });
 

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -54,7 +54,7 @@ const MultimodalPartSchema = z.object({
 export const QuerySchema = z.object({
   prompt: z.string().describe("The text prompt to send to Vertex AI"),
   sessionId: z.string().optional().describe("Optional conversation session ID for multi-turn conversations"),
-  model: z.string().optional().describe("Optional model override (e.g., gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.1-flash-lite-preview, gemini-3.1-pro-preview-customtools)"),
+  model: z.string().optional().describe("Optional model override (e.g., gemini-3.5-flash, gemini-3.1-pro-preview, gemini-3.1-flash-lite, gemini-3.1-pro-preview-customtools)"),
   thinkingLevel: z.enum(['minimal', 'low', 'medium', 'high', 'MINIMAL', 'LOW', 'MEDIUM', 'HIGH']).optional()
     .describe("Optional Gemini 3 thinking level override"),
   mediaResolution: z.enum(['low', 'medium', 'high', 'LOW', 'MEDIUM', 'HIGH']).optional()
@@ -71,8 +71,8 @@ export const FetchSchema = z.object({
 });
 
 const ALLOWED_IMAGE_MODELS = [
-  'gemini-3-pro-image-preview',
-  'gemini-3.1-flash-image-preview',
+  'gemini-3-pro-image',
+  'gemini-3.1-flash-image',
   'gemini-2.5-flash-image',
 ] as const;
 
@@ -85,17 +85,17 @@ const FLASH_IMAGE_ONLY_ASPECT_RATIOS: readonly string[] = ['1:4', '1:8', '4:1', 
 export const ImageGenerationSchema = z.object({
   prompt: z.string().describe("Image generation prompt"),
   model: z.enum(ALLOWED_IMAGE_MODELS).optional()
-    .describe("Image model (default: gemini-3-pro-image-preview)"),
+    .describe("Image model (default: gemini-3-pro-image)"),
   aspectRatio: z.enum(ALLOWED_IMAGE_ASPECT_RATIOS).optional()
-    .describe("Aspect ratio (default: 1:1; 1:4, 1:8, 4:1, and 8:1 require gemini-3.1-flash-image-preview)"),
+    .describe("Aspect ratio (default: 1:1; 1:4, 1:8, 4:1, and 8:1 require gemini-3.1-flash-image)"),
   imageSize: z.enum(['0.5K', '1K', '2K', '4K']).optional()
-    .describe("Resolution (0.5K requires gemini-3.1-flash-image-preview, default: 1K)"),
+    .describe("Resolution (0.5K requires gemini-3.1-flash-image, default: 1K)"),
   imagePaths: z.array(GeminiImageInputPathSchema).max(14).optional()
     .describe(`Local file paths of reference images to include as input (max 14; e.g., for image editing or style transfer). Supported file types: ${GEMINI_IMAGE_INPUT_FILE_TYPES}. Audio/video files are not accepted.`),
   systemInstruction: z.string().optional()
     .describe("Optional system instruction for Gemini 3 image models"),
   thinkingLevel: z.enum(['minimal', 'high', 'MINIMAL', 'HIGH']).optional()
-    .describe("Optional thinking level; only supported by gemini-3.1-flash-image-preview"),
+    .describe("Optional thinking level; only supported by gemini-3.1-flash-image"),
   mediaResolution: z.enum(['low', 'medium', 'high', 'LOW', 'MEDIUM', 'HIGH']).optional()
     .describe("Optional media resolution for reference image inputs"),
 }).strict().refine(
@@ -103,15 +103,15 @@ export const ImageGenerationSchema = z.object({
     if (!data.aspectRatio) {
       return true;
     }
-    return data.model === 'gemini-3.1-flash-image-preview' ||
+    return data.model === 'gemini-3.1-flash-image' ||
       !FLASH_IMAGE_ONLY_ASPECT_RATIOS.includes(data.aspectRatio);
   },
-  { message: "aspectRatio 1:4, 1:8, 4:1, and 8:1 require model='gemini-3.1-flash-image-preview'" }
+  { message: "aspectRatio 1:4, 1:8, 4:1, and 8:1 require model='gemini-3.1-flash-image'" }
 ).refine(
   (data) => {
-    return data.imageSize !== '0.5K' || data.model === 'gemini-3.1-flash-image-preview';
+    return data.imageSize !== '0.5K' || data.model === 'gemini-3.1-flash-image';
   },
-  { message: "imageSize '0.5K' requires model='gemini-3.1-flash-image-preview'" }
+  { message: "imageSize '0.5K' requires model='gemini-3.1-flash-image'" }
 ).refine(
   (data) => {
     return data.model !== 'gemini-2.5-flash-image' || data.imageSize === undefined;
@@ -119,9 +119,9 @@ export const ImageGenerationSchema = z.object({
   { message: "imageSize is not supported by model='gemini-2.5-flash-image'; omit imageSize for its 1K output" }
 ).refine(
   (data) => {
-    return !data.thinkingLevel || data.model === 'gemini-3.1-flash-image-preview';
+    return !data.thinkingLevel || data.model === 'gemini-3.1-flash-image';
   },
-  { message: "thinkingLevel is only supported by model='gemini-3.1-flash-image-preview'" }
+  { message: "thinkingLevel is only supported by model='gemini-3.1-flash-image'" }
 ).refine(
   (data) => {
     return data.model !== 'gemini-2.5-flash-image' || !data.imagePaths || data.imagePaths.length <= 3;
@@ -271,6 +271,10 @@ export function buildVideoGenerationSchema(useVertexAI: boolean = true) {
       .describe(`Local file paths of reference images (max 3). Supported file types: ${VEO_IMAGE_INPUT_FILE_TYPES}`),
     videoPath: VeoExtensionVideoPathSchema.optional()
       .describe(`Local file path of a Veo-generated 720p video to extend. Supported file types: ${VEO_EXTENSION_VIDEO_FILE_TYPES}`),
+    compressionQuality: z.enum(['optimized', 'lossless']).optional()
+      .describe("Output video compression quality (Vertex AI only): 'optimized' (smaller file, default) or 'lossless' (larger, highest quality)"),
+    resizeMode: z.enum(['crop', 'pad']).optional()
+      .describe("How the input image is fit to the target aspect ratio for image-to-video (Vertex AI only; requires imagePath): 'crop' or 'pad' (default pad)"),
   }).strict().refine(
     (data) => {
       if (data.resolution === '1080p' || data.resolution === '4k') {
@@ -368,6 +372,18 @@ export function buildVideoGenerationSchema(useVertexAI: boolean = true) {
       return data.personGeneration === 'allow_all';
     },
     { message: "Gemini Developer API Veo 3.1 uses personGeneration='allow_all' for text/video extension and 'allow_adult' for image/reference modes" }
+  ).refine(
+    (data) => useVertexAI || data.compressionQuality === undefined,
+    { message: "compressionQuality is only supported in Vertex AI mode" }
+  ).refine(
+    (data) => useVertexAI || data.resizeMode === undefined,
+    { message: "resizeMode is only supported in Vertex AI mode" }
+  ).refine(
+    (data) => !data.resizeMode || !!data.imagePath,
+    { message: "resizeMode requires imagePath (image-to-video mode)" }
+  ).refine(
+    (data) => !data.resizeMode || !data.referenceImagePaths?.length,
+    { message: "resizeMode cannot be used with referenceImagePaths" }
   );
 }
 

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from "zod";
+import { Backend } from "../types/config.js";
 
 export const GEMINI_IMAGE_INPUT_FILE_TYPES = 'PNG (.png), JPEG (.jpg/.jpeg), WEBP (.webp), HEIC (.heic), HEIF (.heif)';
 export const VEO_IMAGE_INPUT_FILE_TYPES = 'PNG (.png), JPEG (.jpg/.jpeg), WEBP (.webp)';
@@ -55,6 +56,8 @@ export const QuerySchema = z.object({
   prompt: z.string().describe("The text prompt to send to Vertex AI"),
   sessionId: z.string().optional().describe("Optional conversation session ID for multi-turn conversations"),
   model: z.string().optional().describe("Optional model override (e.g., gemini-3.5-flash, gemini-3.1-pro-preview, gemini-3.1-flash-lite, gemini-3.1-pro-preview-customtools)"),
+  backend: z.enum(['vertex', 'ai-studio']).optional()
+    .describe("Optional backend override ('vertex' | 'ai-studio'); defaults to the server's configured backend"),
   thinkingLevel: z.enum(['minimal', 'low', 'medium', 'high', 'MINIMAL', 'LOW', 'MEDIUM', 'HIGH']).optional()
     .describe("Optional Gemini 3 thinking level override"),
   mediaResolution: z.enum(['low', 'medium', 'high', 'LOW', 'MEDIUM', 'HIGH']).optional()
@@ -86,6 +89,8 @@ export const ImageGenerationSchema = z.object({
   prompt: z.string().describe("Image generation prompt"),
   model: z.enum(ALLOWED_IMAGE_MODELS).optional()
     .describe("Image model (default: gemini-3-pro-image)"),
+  backend: z.enum(['vertex', 'ai-studio']).optional()
+    .describe("Optional backend override ('vertex' | 'ai-studio'); defaults to the server's configured backend"),
   aspectRatio: z.enum(ALLOWED_IMAGE_ASPECT_RATIOS).optional()
     .describe("Aspect ratio (default: 1:1; 1:4, 1:8, 4:1, and 8:1 require gemini-3.1-flash-image)"),
   imageSize: z.enum(['0.5K', '1K', '2K', '4K']).optional()
@@ -164,6 +169,8 @@ export const SpeechGenerationSchema = z.object({
   prompt: z.string().describe("Text or transcript to synthesize as speech. Gemini TTS is text-only input; audio/image/video reference files are not accepted."),
   model: z.enum(ALLOWED_SPEECH_MODELS).optional()
     .describe("Speech model (default: gemini-3.1-flash-tts-preview)"),
+  backend: z.enum(['vertex', 'ai-studio']).optional()
+    .describe("Optional backend override ('vertex' | 'ai-studio'); defaults to the server's configured backend"),
   voiceName: z.string().min(1).optional()
     .describe("Prebuilt voice name for single-speaker TTS (default: Kore)"),
   languageCode: z.string().min(2).optional()
@@ -195,15 +202,20 @@ export function getAllowedMusicOutputMimeTypes(useVertexAI: boolean = true): rea
   return useVertexAI ? ['audio/mp3'] : ['audio/mp3', 'audio/wav'];
 }
 
-export function buildMusicGenerationSchema(useVertexAI: boolean = true) {
+export function buildMusicGenerationSchema(
+  useVertexAI: boolean = true,
+  availableBackends: Backend[] = [useVertexAI ? 'vertex' : 'ai-studio'],
+) {
+  const defaultBackend: Backend = useVertexAI ? 'vertex' : 'ai-studio';
+  const isVertex = (data: { backend?: Backend }): boolean => (data.backend ?? defaultBackend) === 'vertex';
   return z.object({
     prompt: z.string().describe("Music generation prompt"),
+    backend: z.enum(availableBackends as [Backend, ...Backend[]]).optional()
+      .describe(`Backend for this request (default: ${defaultBackend}; available: ${availableBackends.join(', ')}). Vertex AI supports audio/mp3 only; Google AI Studio adds audio/wav for lyria-3-pro-preview.`),
     model: z.enum(ALLOWED_MUSIC_MODELS).optional()
       .describe("Music model (default: lyria-3-clip-preview)"),
     outputMimeType: z.enum(['audio/mp3', 'audio/wav']).optional()
-      .describe(useVertexAI
-        ? "Optional output MIME type; Vertex AI Lyria 3 model card supports audio/mp3 only"
-        : "Optional output MIME type; Gemini API defaults to audio/mp3 and supports audio/wav only with lyria-3-pro-preview"),
+      .describe("Optional output MIME type. Vertex AI supports audio/mp3 only; Google AI Studio supports audio/wav for lyria-3-pro-preview."),
     imagePaths: z.array(GeminiImageInputPathSchema).max(10).optional()
       .describe(`Optional local image paths to use as multimodal Lyria music generation inputs (max 10). Supported Gemini image input file types: ${GEMINI_IMAGE_INPUT_FILE_TYPES}. Audio/video reference files are not accepted by Lyria 3.`),
     lyrics: z.string().optional()
@@ -227,22 +239,36 @@ export function buildMusicGenerationSchema(useVertexAI: boolean = true) {
     (data) => !data.instrumental || (!data.lyrics && !data.vocalStyle),
     { message: "instrumental cannot be combined with lyrics or vocalStyle" }
   ).refine(
-    (data) => !useVertexAI || data.outputMimeType === undefined || data.outputMimeType === 'audio/mp3',
-    { message: "Vertex AI Lyria 3 supports outputMimeType='audio/mp3' only" }
+    (data) => !isVertex(data) || data.outputMimeType === undefined || data.outputMimeType === 'audio/mp3',
+    { message: "the Vertex AI backend supports outputMimeType='audio/mp3' only for Lyria 3" }
   ).refine(
-    (data) => useVertexAI || data.outputMimeType !== 'audio/wav' || data.model === 'lyria-3-pro-preview',
-    { message: "outputMimeType='audio/wav' requires model='lyria-3-pro-preview' in Gemini API mode" }
+    (data) => isVertex(data) || data.outputMimeType !== 'audio/wav' || data.model === 'lyria-3-pro-preview',
+    { message: "outputMimeType='audio/wav' requires model='lyria-3-pro-preview' on the Google AI Studio backend" }
   );
 }
 
 export const MusicGenerationSchema = buildMusicGenerationSchema(true);
 
-export function buildVideoGenerationSchema(useVertexAI: boolean = true) {
-  const allowedVideoModels = useVertexAI ? ALLOWED_VERTEX_VIDEO_MODELS : ALLOWED_GEMINI_API_VIDEO_MODELS;
-  const maxVideoCount = useVertexAI ? 4 : 1;
+export function buildVideoGenerationSchema(
+  useVertexAI: boolean = true,
+  availableBackends: Backend[] = [useVertexAI ? 'vertex' : 'ai-studio'],
+) {
+  const defaultBackend: Backend = useVertexAI ? 'vertex' : 'ai-studio';
+  const dual = availableBackends.length > 1;
+  const allowedVideoModels = (dual
+    ? [...ALLOWED_VERTEX_VIDEO_MODELS, ...ALLOWED_GEMINI_API_VIDEO_MODELS]
+    : (useVertexAI ? ALLOWED_VERTEX_VIDEO_MODELS : ALLOWED_GEMINI_API_VIDEO_MODELS)
+  ) as [string, ...string[]];
+  const maxVideoCount = dual ? 4 : (useVertexAI ? 4 : 1);
+  const effBackend = (data: { backend?: Backend }): Backend => data.backend ?? defaultBackend;
+  const isVertex = (data: { backend?: Backend }): boolean => effBackend(data) === 'vertex';
+  const modelsForBackend = (b: Backend): readonly string[] =>
+    b === 'vertex' ? ALLOWED_VERTEX_VIDEO_MODELS : ALLOWED_GEMINI_API_VIDEO_MODELS;
 
   return z.object({
     prompt: z.string().describe("Video generation prompt"),
+    backend: z.enum(availableBackends as [Backend, ...Backend[]]).optional()
+      .describe(`Backend for this request (default: ${defaultBackend}; available: ${availableBackends.join(', ')}). Vertex AI uses '-001' model IDs and Vertex-only controls (seed, generateAudio, numberOfVideos>1, compressionQuality, resizeMode); Google AI Studio uses '-preview' IDs.`),
     model: z.enum(allowedVideoModels).optional()
       .describe(`Video model (default: ${getDefaultVideoModel(useVertexAI)})`),
     aspectRatio: z.enum(['16:9', '9:16']).optional()
@@ -276,6 +302,9 @@ export function buildVideoGenerationSchema(useVertexAI: boolean = true) {
     resizeMode: z.enum(['crop', 'pad']).optional()
       .describe("How the input image is fit to the target aspect ratio for image-to-video (Vertex AI only; requires imagePath): 'crop' or 'pad' (default pad)"),
   }).strict().refine(
+    (data) => !data.model || modelsForBackend(effBackend(data)).includes(data.model),
+    { message: "model does not match the selected backend; Vertex AI uses '-001' model IDs and Google AI Studio uses '-preview' model IDs" }
+  ).refine(
     (data) => {
       if (data.resolution === '1080p' || data.resolution === '4k') {
         return data.durationSeconds === undefined || data.durationSeconds === '8';
@@ -352,17 +381,17 @@ export function buildVideoGenerationSchema(useVertexAI: boolean = true) {
     (data) => data.model !== 'veo-3.1-lite-generate-preview' || data.resolution !== '4k',
     { message: "resolution '4k' is not supported by model='veo-3.1-lite-generate-preview'" }
   ).refine(
-    (data) => useVertexAI || data.generateAudio === undefined,
-    { message: "generateAudio is always on and cannot be configured in Gemini Developer API mode" }
+    (data) => isVertex(data) || data.generateAudio === undefined,
+    { message: "generateAudio is always on and cannot be configured for the Google AI Studio backend" }
   ).refine(
-    (data) => useVertexAI || data.seed === undefined,
-    { message: "seed is not supported by @google/genai generateVideos in Gemini Developer API mode" }
+    (data) => isVertex(data) || data.seed === undefined,
+    { message: "seed is not supported by @google/genai generateVideos for the Google AI Studio backend" }
   ).refine(
-    (data) => useVertexAI || data.numberOfVideos === undefined || data.numberOfVideos === 1,
-    { message: "Gemini Developer API Veo 3.1 returns a single video; omit numberOfVideos or set it to 1" }
+    (data) => isVertex(data) || data.numberOfVideos === undefined || data.numberOfVideos === 1,
+    { message: "Google AI Studio Veo 3.1 returns a single video; omit numberOfVideos or set it to 1" }
   ).refine(
     (data) => {
-      if (useVertexAI || !data.personGeneration) {
+      if (isVertex(data) || !data.personGeneration) {
         return true;
       }
       const usesImageMode = !!data.imagePath || !!data.lastFramePath || !!data.referenceImagePaths?.length;
@@ -373,11 +402,11 @@ export function buildVideoGenerationSchema(useVertexAI: boolean = true) {
     },
     { message: "Gemini Developer API Veo 3.1 uses personGeneration='allow_all' for text/video extension and 'allow_adult' for image/reference modes" }
   ).refine(
-    (data) => useVertexAI || data.compressionQuality === undefined,
-    { message: "compressionQuality is only supported in Vertex AI mode" }
+    (data) => isVertex(data) || data.compressionQuality === undefined,
+    { message: "compressionQuality is only supported by the Vertex AI backend" }
   ).refine(
-    (data) => useVertexAI || data.resizeMode === undefined,
-    { message: "resizeMode is only supported in Vertex AI mode" }
+    (data) => isVertex(data) || data.resizeMode === undefined,
+    { message: "resizeMode is only supported by the Vertex AI backend" }
   ).refine(
     (data) => !data.resizeMode || !!data.imagePath,
     { message: "resizeMode requires imagePath (image-to-video mode)" }

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -53,7 +53,7 @@ const MultimodalPartSchema = z.object({
 });
 
 export const QuerySchema = z.object({
-  prompt: z.string().describe("The text prompt to send to Vertex AI"),
+  prompt: z.string().describe("The text prompt to send to the model"),
   sessionId: z.string().optional().describe("Optional conversation session ID for multi-turn conversations"),
   model: z.string().optional().describe("Optional model override (e.g., gemini-3.5-flash, gemini-3.1-pro-preview, gemini-3.1-flash-lite, gemini-3.1-pro-preview-customtools)"),
   backend: z.enum(['vertex', 'ai-studio']).optional()

--- a/src/server/GeminiAIMCPServer.test.ts
+++ b/src/server/GeminiAIMCPServer.test.ts
@@ -204,8 +204,8 @@ describe('GeminiAIMCPServer generate_image wiring', () => {
     expect(imageGenTool.inputSchema.properties.aspectRatio).toBeDefined();
     expect(imageGenTool.inputSchema.properties.imageSize).toBeDefined();
     expect(imageGenTool.inputSchema.properties.model.enum).toEqual([
-      'gemini-3-pro-image-preview',
-      'gemini-3.1-flash-image-preview',
+      'gemini-3-pro-image',
+      'gemini-3.1-flash-image',
       'gemini-2.5-flash-image',
     ]);
     expect(imageGenTool.inputSchema.properties.aspectRatio.enum).toContain('1:4');
@@ -310,7 +310,7 @@ describe('GeminiAIMCPServer generate_image wiring', () => {
       'audio/mp3',
       'audio/wav',
     ]);
-    expect(musicTool.description).toContain('Gemini API/AI Studio mode supports audio/mp3 output');
+    expect(musicTool.description).toContain('Gemini API/AI Studio mode supports 44.1 kHz stereo audio/mp3 output');
 
     await handlers.callHandler({
       params: {
@@ -383,7 +383,7 @@ describe('GeminiAIMCPServer generate_image wiring', () => {
       {
         path: '(root)',
         code: 'custom',
-        message: "imageSize '0.5K' requires model='gemini-3.1-flash-image-preview'",
+        message: "imageSize '0.5K' requires model='gemini-3.1-flash-image'",
       },
     ]);
   });

--- a/src/server/GeminiAIMCPServer.ts
+++ b/src/server/GeminiAIMCPServer.ts
@@ -168,7 +168,7 @@ export class GeminiAIMCPServer {
               },
               model: {
                 type: "string",
-                description: "Optional model override (e.g., gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.1-flash-lite-preview, gemini-3.1-pro-preview-customtools)",
+                description: "Optional model override (e.g., gemini-3.5-flash, gemini-3.1-pro-preview, gemini-3.1-flash-lite, gemini-3.1-pro-preview-customtools)",
               },
               thinkingLevel: {
                 type: "string",
@@ -267,8 +267,8 @@ export class GeminiAIMCPServer {
           name: "generate_image",
           description:
             "Generate images using Gemini's native image generation (Nano Banana). " +
-            "Supports gemini-3-pro-image-preview, gemini-3.1-flash-image-preview, and gemini-2.5-flash-image models. " +
-            "gemini-2.5-flash-image supports at most 3 reference images and does not support imageSize; gemini-3.1-flash-image-preview is required for 0.5K and 1:4/1:8/4:1/8:1 ratios. " +
+            "Supports gemini-3-pro-image, gemini-3.1-flash-image, and gemini-2.5-flash-image models. " +
+            "gemini-2.5-flash-image supports at most 3 reference images and does not support imageSize; gemini-3.1-flash-image is required for 0.5K and 1:4/1:8/4:1/8:1 ratios. " +
             `Reference images use imagePaths and must be ${GEMINI_IMAGE_INPUT_FILE_TYPES}. ` +
             "Audio and video reference files are not accepted by generate_image. " +
             `Images are saved to ${this.imageGenerationHandler.getImageOutputDir()} and returned as base64.`,
@@ -282,18 +282,18 @@ export class GeminiAIMCPServer {
               },
               model: {
                 type: "string",
-                enum: ["gemini-3-pro-image-preview", "gemini-3.1-flash-image-preview", "gemini-2.5-flash-image"],
-                description: "Image model (default: gemini-3-pro-image-preview; gemini-2.5-flash-image supports at most 3 reference images and does not support imageSize)",
+                enum: ["gemini-3-pro-image", "gemini-3.1-flash-image", "gemini-2.5-flash-image"],
+                description: "Image model (default: gemini-3-pro-image; gemini-2.5-flash-image supports at most 3 reference images and does not support imageSize, and retires 2026-10-02 — prefer gemini-3.1-flash-image)",
               },
               aspectRatio: {
                 type: "string",
                 enum: ["1:1", "1:4", "1:8", "2:3", "3:2", "3:4", "4:1", "4:3", "4:5", "5:4", "8:1", "9:16", "16:9", "21:9"],
-                description: "Aspect ratio (default: 1:1; 1:4, 1:8, 4:1, and 8:1 require gemini-3.1-flash-image-preview)",
+                description: "Aspect ratio (default: 1:1; 1:4, 1:8, 4:1, and 8:1 require gemini-3.1-flash-image)",
               },
               imageSize: {
                 type: "string",
                 enum: ["0.5K", "1K", "2K", "4K"],
-                description: "Resolution (0.5K requires gemini-3.1-flash-image-preview, default: 1K)",
+                description: "Resolution (0.5K requires gemini-3.1-flash-image, default: 1K)",
               },
               imagePaths: {
                 type: "array",
@@ -308,7 +308,7 @@ export class GeminiAIMCPServer {
               thinkingLevel: {
                 type: "string",
                 enum: ["minimal", "high", "MINIMAL", "HIGH"],
-                description: "Optional thinking level; only supported by gemini-3.1-flash-image-preview",
+                description: "Optional thinking level; only supported by gemini-3.1-flash-image",
               },
               mediaResolution: {
                 type: "string",
@@ -530,6 +530,16 @@ export class GeminiAIMCPServer {
               videoPath: {
                 type: "string",
                 description: `Local file path of a Veo-generated 720p input video to extend. Supported file types: ${VEO_EXTENSION_VIDEO_FILE_TYPES}`,
+              },
+              compressionQuality: {
+                type: "string",
+                enum: ["optimized", "lossless"],
+                description: "Output video compression quality (Vertex AI only): 'optimized' (smaller file, default) or 'lossless' (larger, highest quality)",
+              },
+              resizeMode: {
+                type: "string",
+                enum: ["crop", "pad"],
+                description: "How the input image is fit to the target aspect ratio for image-to-video (Vertex AI only; requires imagePath): 'crop' or 'pad' (default pad)",
               },
             },
             required: ["prompt"],

--- a/src/server/GeminiAIMCPServer.ts
+++ b/src/server/GeminiAIMCPServer.ts
@@ -602,6 +602,14 @@ export class GeminiAIMCPServer {
       const toolName = request.params.name;
       const args = request.params.arguments || {};
 
+      // The `backend` selector is only advertised when multiple backends are
+      // configured. In single-backend deployments, ignore any `backend` arg so
+      // runtime behavior matches the advertised tool contract.
+      const configuredBackends = this.config.availableBackends ?? [this.config.useVertexAI ? 'vertex' : 'ai-studio'];
+      if (configuredBackends.length < 2 && args && typeof args === 'object') {
+        delete (args as Record<string, unknown>).backend;
+      }
+
       try {
         switch (toolName) {
           case "query": {

--- a/src/server/GeminiAIMCPServer.ts
+++ b/src/server/GeminiAIMCPServer.ts
@@ -136,13 +136,25 @@ export class GeminiAIMCPServer {
   private setupHandlers(): void {
     // List available tools
     this.server.setRequestHandler(ListToolsRequestSchema, async () => {
-      const videoModelEnum = getAllowedVideoModels(this.config.useVertexAI);
+      const availableBackends = this.config.availableBackends ?? [this.config.useVertexAI ? 'vertex' : 'ai-studio'];
+      const defaultBackend = this.config.defaultBackend ?? (this.config.useVertexAI ? 'vertex' : 'ai-studio');
+      const dual = availableBackends.length > 1;
+      const backendProp = {
+        type: "string",
+        enum: availableBackends,
+        description: `Backend for this request (default: ${defaultBackend}; available: ${availableBackends.join(', ')}). Vertex AI uses '-001' video model IDs and Vertex-only controls; Google AI Studio uses '-preview' IDs.`,
+      };
+      const videoModelEnum = dual
+        ? [...getAllowedVideoModels(true), ...getAllowedVideoModels(false)]
+        : getAllowedVideoModels(this.config.useVertexAI);
       const defaultVideoModel = getDefaultVideoModel(this.config.useVertexAI);
-      const maxVideoCount = this.config.useVertexAI ? 4 : 1;
-      const musicOutputMimeTypes = getAllowedMusicOutputMimeTypes(this.config.useVertexAI);
-      const musicOutputMimeDescription = this.config.useVertexAI
-        ? "Optional output MIME type; Vertex AI Lyria 3 model card supports audio/mp3 only"
-        : "Optional output MIME type; Gemini API/AI Studio defaults to audio/mp3 and supports audio/wav only with lyria-3-pro-preview";
+      const maxVideoCount = dual ? 4 : (this.config.useVertexAI ? 4 : 1);
+      const musicOutputMimeTypes = dual ? ['audio/mp3', 'audio/wav'] : getAllowedMusicOutputMimeTypes(this.config.useVertexAI);
+      const musicOutputMimeDescription = dual
+        ? "Optional output MIME type. Vertex AI supports audio/mp3 only; Google AI Studio supports audio/wav for lyria-3-pro-preview."
+        : (this.config.useVertexAI
+          ? "Optional output MIME type; Vertex AI Lyria 3 model card supports audio/mp3 only"
+          : "Optional output MIME type; Gemini API/AI Studio defaults to audio/mp3 and supports audio/wav only with lyria-3-pro-preview");
 
       const tools = [
         {
@@ -565,6 +577,23 @@ export class GeminiAIMCPServer {
         },
       ];
 
+      // When more than one backend is configured, advertise the per-request
+      // `backend` selector on every generation tool so callers can switch.
+      if (dual) {
+        const backendTools = new Set([
+          "query",
+          "generate_image",
+          "generate_speech",
+          "generate_video",
+          "generate_music",
+        ]);
+        for (const tool of tools) {
+          if (backendTools.has(tool.name)) {
+            (tool.inputSchema.properties as Record<string, unknown>).backend = backendProp;
+          }
+        }
+      }
+
       return { tools };
     });
 
@@ -601,12 +630,12 @@ export class GeminiAIMCPServer {
           }
 
           case "generate_music": {
-            const input = buildMusicGenerationSchema(this.config.useVertexAI).parse(args);
+            const input = buildMusicGenerationSchema(this.config.useVertexAI, this.config.availableBackends).parse(args);
             return await this.musicGenerationHandler.handle(input);
           }
 
           case "generate_video": {
-            const input = buildVideoGenerationSchema(this.config.useVertexAI).parse(args);
+            const input = buildVideoGenerationSchema(this.config.useVertexAI, this.config.availableBackends).parse(args);
             return await this.videoGenerationHandler.handle(input);
           }
 

--- a/src/services/GeminiAIService.test.ts
+++ b/src/services/GeminiAIService.test.ts
@@ -265,6 +265,37 @@ describe('generateVideo backend compatibility', () => {
     expect(params.config).not.toHaveProperty('generateAudio');
     expect(params.config).not.toHaveProperty('seed');
   });
+
+  it('maps compressionQuality and resizeMode to SDK enum values in Vertex mode', async () => {
+    const service = new GeminiAIService(createServiceConfig());
+    const generateVideos = stubGenerateVideos(service);
+
+    await service.generateVideo('animate this frame', {
+      compressionQuality: 'lossless',
+      resizeMode: 'crop',
+    });
+
+    const params = generateVideos.mock.calls[0][0];
+    expect(params.config.compressionQuality).toBe('LOSSLESS');
+    expect(params.config.resizeMode).toBe('CROP');
+  });
+
+  it('omits compressionQuality and resizeMode in Gemini Developer API mode', async () => {
+    const service = new GeminiAIService(createServiceConfig({
+      useVertexAI: false,
+      projectId: undefined,
+    }));
+    const generateVideos = stubGenerateVideos(service);
+
+    await service.generateVideo('animate this frame', {
+      compressionQuality: 'lossless',
+      resizeMode: 'crop',
+    });
+
+    const params = generateVideos.mock.calls[0][0];
+    expect(params.config).not.toHaveProperty('compressionQuality');
+    expect(params.config).not.toHaveProperty('resizeMode');
+  });
 });
 
 describe('QueryOptions interface', () => {

--- a/src/services/GeminiAIService.test.ts
+++ b/src/services/GeminiAIService.test.ts
@@ -199,6 +199,55 @@ describe('generated audio output config', () => {
   });
 });
 
+describe('backend availability detection', () => {
+  it('exposes both backends when both credentials are present', async () => {
+    const savedKey = process.env.GEMINI_API_KEY;
+    const savedGoogleKey = process.env.GOOGLE_API_KEY;
+    const savedProject = process.env.GOOGLE_CLOUD_PROJECT;
+    const savedUseVertex = process.env.GOOGLE_GENAI_USE_VERTEXAI;
+    process.env.GEMINI_API_KEY = 'test-key';
+    process.env.GOOGLE_CLOUD_PROJECT = 'test-project';
+    delete process.env.GOOGLE_GENAI_USE_VERTEXAI;
+
+    try {
+      const { loadConfig } = await import('../config/index.js');
+      const config = loadConfig();
+      expect(config.availableBackends).toContain('vertex');
+      expect(config.availableBackends).toContain('ai-studio');
+      expect(config.availableBackends).toHaveLength(2);
+      // project present and no explicit override -> vertex is the default
+      expect(config.defaultBackend).toBe('vertex');
+      expect(config.useVertexAI).toBe(true);
+    } finally {
+      if (savedKey !== undefined) process.env.GEMINI_API_KEY = savedKey; else delete process.env.GEMINI_API_KEY;
+      if (savedGoogleKey !== undefined) process.env.GOOGLE_API_KEY = savedGoogleKey; else delete process.env.GOOGLE_API_KEY;
+      if (savedProject !== undefined) process.env.GOOGLE_CLOUD_PROJECT = savedProject; else delete process.env.GOOGLE_CLOUD_PROJECT;
+      if (savedUseVertex !== undefined) process.env.GOOGLE_GENAI_USE_VERTEXAI = savedUseVertex; else delete process.env.GOOGLE_GENAI_USE_VERTEXAI;
+    }
+  });
+
+  it('explicit GOOGLE_GENAI_USE_VERTEXAI=false defaults to ai-studio even with a project set', async () => {
+    const savedKey = process.env.GEMINI_API_KEY;
+    const savedProject = process.env.GOOGLE_CLOUD_PROJECT;
+    const savedUseVertex = process.env.GOOGLE_GENAI_USE_VERTEXAI;
+    process.env.GEMINI_API_KEY = 'test-key';
+    process.env.GOOGLE_CLOUD_PROJECT = 'test-project';
+    process.env.GOOGLE_GENAI_USE_VERTEXAI = 'false';
+
+    try {
+      const { loadConfig } = await import('../config/index.js');
+      const config = loadConfig();
+      expect(config.defaultBackend).toBe('ai-studio');
+      expect(config.availableBackends).toContain('vertex');
+      expect(config.availableBackends[0]).toBe('ai-studio');
+    } finally {
+      if (savedKey !== undefined) process.env.GEMINI_API_KEY = savedKey; else delete process.env.GEMINI_API_KEY;
+      if (savedProject !== undefined) process.env.GOOGLE_CLOUD_PROJECT = savedProject; else delete process.env.GOOGLE_CLOUD_PROJECT;
+      if (savedUseVertex !== undefined) process.env.GOOGLE_GENAI_USE_VERTEXAI = savedUseVertex; else delete process.env.GOOGLE_GENAI_USE_VERTEXAI;
+    }
+  });
+});
+
 describe('generateVideo backend compatibility', () => {
   function createServiceConfig(overrides: Record<string, unknown> = {}) {
     return {
@@ -227,9 +276,10 @@ describe('generateVideo backend compatibility', () => {
     const generateVideos = vi.fn().mockResolvedValue({
       name: 'projects/test-project/locations/us-central1/operations/op-123',
     });
-    (service as any).client = {
+    (service as any).clientFor = () => ({
       models: { generateVideos },
-    };
+      operations: {},
+    });
     return generateVideos;
   }
 
@@ -295,6 +345,46 @@ describe('generateVideo backend compatibility', () => {
     const params = generateVideos.mock.calls[0][0];
     expect(params.config).not.toHaveProperty('compressionQuality');
     expect(params.config).not.toHaveProperty('resizeMode');
+  });
+
+  it('routes per-request backend override (default vertex, request ai-studio)', async () => {
+    // Default backend is vertex, but the request selects ai-studio.
+    const service = new GeminiAIService(createServiceConfig({
+      defaultBackend: 'vertex',
+      availableBackends: ['vertex', 'ai-studio'],
+    }));
+    const generateVideos = stubGenerateVideos(service);
+
+    await service.generateVideo('a cinematic ocean shot', {
+      backend: 'ai-studio',
+      seed: 123,
+      compressionQuality: 'lossless',
+    });
+
+    const params = generateVideos.mock.calls[0][0];
+    // ai-studio backend default model + Vertex-only fields omitted
+    expect(params.model).toBe('veo-3.1-fast-generate-preview');
+    expect(params.config).not.toHaveProperty('seed');
+    expect(params.config).not.toHaveProperty('compressionQuality');
+  });
+
+  it('routes per-request backend override (default ai-studio, request vertex)', async () => {
+    const service = new GeminiAIService(createServiceConfig({
+      useVertexAI: false,
+      defaultBackend: 'ai-studio',
+      availableBackends: ['ai-studio', 'vertex'],
+    }));
+    const generateVideos = stubGenerateVideos(service);
+
+    await service.generateVideo('a cinematic ocean shot', {
+      backend: 'vertex',
+      seed: 123,
+    });
+
+    const params = generateVideos.mock.calls[0][0];
+    expect(params.model).toBe('veo-3.1-fast-generate-001');
+    expect(params.config.seed).toBe(123);
+    expect(params.config.generateAudio).toBe(true);
   });
 });
 

--- a/src/services/GeminiAIService.test.ts
+++ b/src/services/GeminiAIService.test.ts
@@ -22,12 +22,16 @@ describe('isGemini3Model regex pattern', () => {
     expect(isGemini3Pattern.test('gemini-3-flash-preview')).toBe(true);
   });
 
-  it('matches gemini-3-pro-image-preview', () => {
-    expect(isGemini3Pattern.test('gemini-3-pro-image-preview')).toBe(true);
+  it('matches gemini-3.5-flash', () => {
+    expect(isGemini3Pattern.test('gemini-3.5-flash')).toBe(true);
   });
 
-  it('matches gemini-3.1-flash-image-preview', () => {
-    expect(isGemini3Pattern.test('gemini-3.1-flash-image-preview')).toBe(true);
+  it('matches gemini-3-pro-image', () => {
+    expect(isGemini3Pattern.test('gemini-3-pro-image')).toBe(true);
+  });
+
+  it('matches gemini-3.1-flash-image', () => {
+    expect(isGemini3Pattern.test('gemini-3.1-flash-image')).toBe(true);
   });
 
   it('matches gemini3 (no separator)', () => {
@@ -58,7 +62,7 @@ describe('ThinkingLevel enum from SDK', () => {
 });
 
 describe('default model configuration', () => {
-  it('defaults to gemini-3-flash-preview', async () => {
+  it('defaults to gemini-3.5-flash', async () => {
     // Save and clear env
     const savedModel = process.env.GEMINI_MODEL;
     const savedProject = process.env.GOOGLE_CLOUD_PROJECT;
@@ -71,7 +75,7 @@ describe('default model configuration', () => {
       // Dynamic import to get fresh module
       const { loadConfig } = await import('../config/index.js');
       const config = loadConfig();
-      expect(config.model).toBe('gemini-3-flash-preview');
+      expect(config.model).toBe('gemini-3.5-flash');
       expect(config.useVertexAI).toBe(true);
     } finally {
       // Restore env
@@ -202,7 +206,7 @@ describe('generateVideo backend compatibility', () => {
       location: 'us-central1',
       apiKey: 'test-api-key',
       useVertexAI: true,
-      model: 'gemini-3-flash-preview',
+      model: 'gemini-3.5-flash',
       temperature: 0.7,
       maxTokens: 8192,
       topP: 0.95,

--- a/src/services/GeminiAIService.test.ts
+++ b/src/services/GeminiAIService.test.ts
@@ -239,7 +239,7 @@ describe('backend availability detection', () => {
       const config = loadConfig();
       expect(config.defaultBackend).toBe('ai-studio');
       expect(config.availableBackends).toContain('vertex');
-      expect(config.availableBackends[0]).toBe('ai-studio');
+      expect(config.availableBackends?.[0]).toBe('ai-studio');
     } finally {
       if (savedKey !== undefined) process.env.GEMINI_API_KEY = savedKey; else delete process.env.GEMINI_API_KEY;
       if (savedProject !== undefined) process.env.GOOGLE_CLOUD_PROJECT = savedProject; else delete process.env.GOOGLE_CLOUD_PROJECT;

--- a/src/services/GeminiAIService.ts
+++ b/src/services/GeminiAIService.ts
@@ -46,6 +46,8 @@ export interface VideoGenerationOptions {
   lastFramePath?: string;
   referenceImagePaths?: string[];
   videoPath?: string;
+  compressionQuality?: string;
+  resizeMode?: string;
 }
 
 export interface GeneratedVideo {
@@ -411,7 +413,7 @@ export class GeminiAIService {
     prompt: string,
     options: ImageGenerationOptions = {}
   ): Promise<{ images: GeneratedImage[]; text?: string }> {
-    const model = options.model || 'gemini-3-pro-image-preview';
+    const model = options.model || 'gemini-3-pro-image';
     const contents = this.buildContentsWithInlineFiles(prompt, options.imagePaths);
     const config: GenerateContentConfig = {
       responseModalities: ['TEXT', 'IMAGE'],
@@ -690,6 +692,12 @@ export class GeminiAIService {
     if (this.config.useVertexAI) {
       params.config.generateAudio = options.generateAudio ?? true;
       params.config.seed = options.seed;
+      if (options.compressionQuality) {
+        params.config.compressionQuality = options.compressionQuality.toUpperCase();
+      }
+      if (options.resizeMode) {
+        params.config.resizeMode = options.resizeMode.toUpperCase();
+      }
     }
 
     // Video extension: attach a Veo-generated input video.

--- a/src/services/GeminiAIService.ts
+++ b/src/services/GeminiAIService.ts
@@ -9,7 +9,7 @@ import { extname, resolve as resolvePath, sep as pathSep } from "node:path";
 
 // Re-export ThinkingLevel for consumers
 export { ThinkingLevel } from "@google/genai";
-import { GeminiAIConfig, MultimodalPart, isSupportedMimeType } from '../types/index.js';
+import { GeminiAIConfig, Backend, MultimodalPart, isSupportedMimeType } from '../types/index.js';
 import { validateSecureUrl } from '../utils/urlSecurity.js';
 import { validateMultimodalFile } from '../utils/fileSecurity.js';
 import { resolveOutputDirs } from '../utils/generatedFileSaver.js';
@@ -24,6 +24,7 @@ export interface ImageGenerationOptions {
   systemInstruction?: string;
   thinkingLevel?: ThinkingLevel | string;
   mediaResolution?: string;
+  backend?: Backend;
 }
 
 export interface GeneratedImage {
@@ -48,6 +49,7 @@ export interface VideoGenerationOptions {
   videoPath?: string;
   compressionQuality?: string;
   resizeMode?: string;
+  backend?: Backend;
 }
 
 export interface GeneratedVideo {
@@ -65,6 +67,7 @@ export interface SpeechGenerationOptions {
   voiceName?: string;
   languageCode?: string;
   speakers?: SpeechSpeakerOptions[];
+  backend?: Backend;
 }
 
 export interface MusicGenerationOptions {
@@ -78,6 +81,7 @@ export interface MusicGenerationOptions {
   durationSeconds?: number;
   bpm?: number;
   intensity?: string;
+  backend?: Backend;
 }
 
 export interface GeneratedAudio {
@@ -106,31 +110,65 @@ export interface QueryOptions {
    * When provided, overrides the ENV-configured model.
    */
   model?: string;
+  /**
+   * Optional backend override ('vertex' | 'ai-studio') for per-request routing.
+   * Defaults to the server's configured default backend.
+   */
+  backend?: Backend;
 }
 
 export class GeminiAIService {
-  private client: GoogleGenAI;
+  private clients = new Map<Backend, GoogleGenAI>();
   private config: GeminiAIConfig;
-  private pendingVideoOps = new Map<string, any>();
+  private pendingVideoOps = new Map<string, { operation: any; backend: Backend }>();
   private extraSafeDirectories: string[];
 
   constructor(config: GeminiAIConfig) {
     this.config = config;
-    this.client = config.useVertexAI
-      ? new GoogleGenAI({
-          vertexai: true,
-          project: config.projectId,
-          location: config.location,
-        })
-      : new GoogleGenAI({
-          apiKey: config.apiKey,
-        });
 
     // Auto-allow this server's own generated-output directories so users can
     // round-trip generated files (e.g. feed a generated image back into query).
     const outputs = resolveOutputDirs(config);
     this.extraSafeDirectories = [outputs.image, outputs.video, outputs.speech, outputs.music]
       .map(d => resolvePath(d));
+  }
+
+  /** Resolve the effective backend for a request (explicit override or default). */
+  private resolveBackend(backend?: Backend): Backend {
+    return backend ?? this.config.defaultBackend ?? (this.config.useVertexAI ? 'vertex' : 'ai-studio');
+  }
+
+  /**
+   * Lazily build and cache a GoogleGenAI client for the given backend.
+   * Throws a clear error when the backend's credentials are not configured.
+   */
+  private clientFor(backend: Backend): GoogleGenAI {
+    const existing = this.clients.get(backend);
+    if (existing) return existing;
+
+    let client: GoogleGenAI;
+    if (backend === 'vertex') {
+      if (!this.config.projectId) {
+        throw new Error(
+          "Vertex AI backend requested but GOOGLE_CLOUD_PROJECT is not configured"
+        );
+      }
+      client = new GoogleGenAI({
+        vertexai: true,
+        project: this.config.projectId,
+        location: this.config.location,
+      });
+    } else {
+      if (!this.config.apiKey) {
+        throw new Error(
+          "Google AI Studio backend requested but GEMINI_API_KEY/GOOGLE_API_KEY is not configured"
+        );
+      }
+      client = new GoogleGenAI({ apiKey: this.config.apiKey });
+    }
+
+    this.clients.set(backend, client);
+    return client;
   }
 
   private isInSelfManagedDir(absolutePath: string): boolean {
@@ -197,7 +235,8 @@ export class GeminiAIService {
       // Build content parts
       const contents = await this.buildContents(prompt, multimodalParts);
 
-      const response = await this.client.models.generateContent({
+      const client = this.clientFor(this.resolveBackend(options.backend));
+      const response = await client.models.generateContent({
         model: effectiveModel,
         contents,
         config,
@@ -437,7 +476,8 @@ export class GeminiAIService {
       config.mediaResolution = mediaResolution;
     }
 
-    const response = await this.client.models.generateContent({
+    const client = this.clientFor(this.resolveBackend(options.backend));
+    const response = await client.models.generateContent({
       model,
       contents,
       config,
@@ -478,7 +518,8 @@ export class GeminiAIService {
       };
     }
 
-    const response = await this.client.models.generateContent({
+    const client = this.clientFor(this.resolveBackend(options.backend));
+    const response = await client.models.generateContent({
       model,
       contents: prompt,
       config: {
@@ -506,7 +547,8 @@ export class GeminiAIService {
       config.responseMimeType = options.outputMimeType;
     }
 
-    const response = await this.client.models.generateContent({
+    const client = this.clientFor(this.resolveBackend(options.backend));
+    const response = await client.models.generateContent({
       model,
       contents: this.buildContentsWithInlineFiles(
         this.buildMusicPrompt(prompt, options),
@@ -672,7 +714,10 @@ export class GeminiAIService {
     prompt: string,
     options: VideoGenerationOptions = {}
   ): Promise<{ operationId: string }> {
-    const model = options.model || getDefaultVideoModel(this.config.useVertexAI);
+    const backend = this.resolveBackend(options.backend);
+    const useVertex = backend === 'vertex';
+    const client = this.clientFor(backend);
+    const model = options.model || getDefaultVideoModel(useVertex);
 
     // Build request parameters
     const params: any = {
@@ -689,7 +734,7 @@ export class GeminiAIService {
       },
     };
 
-    if (this.config.useVertexAI) {
+    if (useVertex) {
       params.config.generateAudio = options.generateAudio ?? true;
       params.config.seed = options.seed;
       if (options.compressionQuality) {
@@ -726,15 +771,15 @@ export class GeminiAIService {
     }
 
     // Start async operation
-    const operation = await this.client.models.generateVideos(params);
+    const operation = await client.models.generateVideos(params);
 
     // Extract UUID from operation name for a cleaner external ID
     // Format: "projects/{project}/locations/{location}/publishers/.../operations/{uuid}"
     const fullName = operation.name || '';
     const operationId = fullName.split('/').pop() || fullName;
 
-    // Cache the full operation object for polling (SDK requires the actual instance)
-    this.pendingVideoOps.set(operationId, operation);
+    // Cache the operation with its backend (polling must use the same client/backend).
+    this.pendingVideoOps.set(operationId, { operation, backend });
 
     return { operationId };
   }
@@ -753,18 +798,20 @@ export class GeminiAIService {
     operationId: string
   ): Promise<{ done: boolean; videos?: GeneratedVideo[]; error?: string }> {
     // Retrieve cached operation object (SDK requires actual operation instance for polling)
-    const cachedOp = this.pendingVideoOps.get(operationId);
-    if (!cachedOp) {
+    const cached = this.pendingVideoOps.get(operationId);
+    if (!cached) {
       return { done: true, error: `Unknown operation: ${operationId}. Operation may have been created in a previous server session.` };
     }
 
-    const operation = await this.client.operations.getVideosOperation({
-      operation: cachedOp,
+    // Poll on the same backend that created the operation.
+    const client = this.clientFor(cached.backend);
+    const operation = await client.operations.getVideosOperation({
+      operation: cached.operation,
     });
 
     if (!operation.done) {
       // Update cached operation with latest state for next poll
-      this.pendingVideoOps.set(operationId, operation);
+      this.pendingVideoOps.set(operationId, { operation, backend: cached.backend });
       return { done: false };
     }
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -5,7 +5,7 @@
 /**
  * Backend that fulfills a generation request.
  * - 'vertex': Vertex AI (requires GOOGLE_CLOUD_PROJECT)
- * - 'ai-studio': Google AI Studio / Gemini Developer API (requires GEMINI_API_KEY)
+ * - 'ai-studio': Google AI Studio / Gemini Developer API (requires GEMINI_API_KEY or GOOGLE_API_KEY)
  */
 export type Backend = 'vertex' | 'ai-studio';
 
@@ -15,10 +15,10 @@ export interface GeminiAIConfig {
   apiKey?: string;
   /** True when the default backend is Vertex AI. Kept for backward compatibility. */
   useVertexAI: boolean;
-  /** Backend used when a request does not specify one. */
-  defaultBackend: Backend;
-  /** Backends that have credentials configured and can serve requests. */
-  availableBackends: Backend[];
+  /** Backend used when a request does not specify one. Populated by loadConfig; consumers should fall back to useVertexAI when absent. */
+  defaultBackend?: Backend;
+  /** Backends that have credentials configured and can serve requests. Populated by loadConfig; consumers should fall back to [useVertexAI ? 'vertex' : 'ai-studio'] when absent. */
+  availableBackends?: Backend[];
   model: string;
   temperature: number;
   maxTokens: number;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -2,11 +2,23 @@
  * Configuration types for Gemini AI MCP Server
  */
 
+/**
+ * Backend that fulfills a generation request.
+ * - 'vertex': Vertex AI (requires GOOGLE_CLOUD_PROJECT)
+ * - 'ai-studio': Google AI Studio / Gemini Developer API (requires GEMINI_API_KEY)
+ */
+export type Backend = 'vertex' | 'ai-studio';
+
 export interface GeminiAIConfig {
   projectId?: string;
   location?: string;
   apiKey?: string;
+  /** True when the default backend is Vertex AI. Kept for backward compatibility. */
   useVertexAI: boolean;
+  /** Backend used when a request does not specify one. */
+  defaultBackend: Backend;
+  /** Backends that have credentials configured and can serve requests. */
+  availableBackends: Backend[];
   model: string;
   temperature: number;
   maxTokens: number;

--- a/src/types/multimodal.ts
+++ b/src/types/multimodal.ts
@@ -52,6 +52,7 @@ export const SUPPORTED_VIDEO_TYPES = [
   'video/mp4',
   'video/mpeg',
   'video/mov',
+  'video/quicktime',
   'video/avi',
   'video/x-flv',
   'video/mpg',
@@ -80,10 +81,13 @@ export const SUPPORTED_DOCUMENT_TYPES = [
   'application/x-typescript',
   'text/csv',
   'text/markdown',
+  'text/md',
   'text/x-python',
+  'application/x-python',
   'application/x-python-code',
   'application/json',
   'text/xml',
+  'text/rtf',
   'application/rtf',
 ] as const;
 


### PR DESCRIPTION
## Summary

Updates the server for Google I/O 2026 announcements, reflects official model deprecations, and widens API-accepted input support — keeping the server a thin, faithful convenience layer over the Gemini/Veo/Lyria APIs.

Driven by research against `@google/genai` 2.x type definitions and first-party docs (`ai.google.dev`, Vertex AI). Every model ID and capability below is verified against an authoritative Google source; nothing is speculative.

## Changes

### Dependency
- Bump `@google/genai` `^1.43.0` → `^2.8.0`. The new GA models need `>=2.5.0`; the old pin capped at 1.52.0. The only 1.x→2.x breaking changes are in the Interactions API, which this server does not use (verified: only `generateContent` / `generateVideos` / `operations.getVideosOperation`).

### Gemini 3.5 Flash (new GA model)
- `query` default `gemini-3-flash-preview` → **`gemini-3.5-flash`** (GA). `query.model` stays free-form, so any model passes through; `isGemini3()` classification verified correct for `gemini-3.5-flash`.

### Deprecation migration (verified at `ai.google.dev/gemini-api/docs/deprecations`)
- `gemini-3.1-flash-lite-preview` (**retired 2026-05-25**) → `gemini-3.1-flash-lite`
- `gemini-3-pro-image-preview` (**retires 2026-06-25**) → `gemini-3-pro-image` (new image default)
- `gemini-3.1-flash-image-preview` (**retires 2026-06-25**) → `gemini-3.1-flash-image` (incl. 5 capability-gating refinements referencing it by string)
- `gemini-2.5-flash-image` (retires 2026-10-02) kept (still valid) with a deprecation note pointing to `gemini-3.1-flash-image`

### API-accepted input expansion
- **Video**: expose `compressionQuality` (`optimized`/`lossless`) and `resizeMode` (`crop`/`pad`, image-to-video), both Vertex-only and gated consistently with `seed`/`generateAudio`. Sourced from the Vertex `VideoGenerationModelParams` schema + SDK enums.
- **Multimodal `fileData`**: align the MIME whitelist with the Files API — add `video/quicktime` (fixes `.mov` being rejected despite the mapper emitting `video/quicktime`), `text/md`, `application/x-python`, `text/rtf`.

### Fixes
- Repair a stale `generate_music` description test assertion (predated this PR; description was made more specific in a prior commit).

## Deliberately NOT changed (with rationale)
- **Gemini Omni Flash** — consumer/app-only as of 2026-06-04; developer API "coming weeks", no published model ID anywhere, no SDK method. Also accepts audio input, which Veo does not — would require a separate tool, not a `generate_video` param. Deferred until an official API ships.
- **Gemini 3.5 Pro** — announced only; no authoritative model ID published. Not invented.
- **Veo `-001` IDs** — kept. These are the Vertex AI GA naming convention (Gemini Developer API uses `-preview`); the repo's existing tests already treat `-001` as GA. Informational: not listed on `ai.google.dev` (Gemini API docs), so worth a live-API reconfirm, but not a regression.
- **Audio input to `generate_video`** — the Veo `generateVideos` API has no audio-input field (confirmed in SDK types + docs). Not added.
- **Speech/Music expansion** — investigation showed the schemas already match the API exactly (2-speaker max is the real limit; Lyria does not support negativePrompt/seed). No change warranted.
- `docs/adr/*` left intact as historical records.

## Verification
- `npm run build` (tsc) passes against `@google/genai` 2.8.0.
- **71/71** unit tests pass (`vitest`), including 4 new tests for the video `compressionQuality`/`resizeMode` gating and the repaired music test.
- Server boot smoke test: lists all 8 tools; `generate_video` exposes the new fields; `generate_image` enum resolves to the GA IDs.

## Follow-ups (not in this PR)
- Optional convenience: local-file-path input for `query` (currently base64/URI only) — would need `getMimeTypeFromExtension` audio/PDF coverage + path security gating.