### PR TITLE
feat(backend): per-request Vertex / Google AI Studio switching

### DIFF
--- a/src/agentic/AgenticLoop.ts
+++ b/src/agentic/AgenticLoop.ts
@@ -77,6 +77,7 @@ export class AgenticLoop {
           model: options.model,
           thinkingLevel: options.thinkingLevel,
           mediaResolution: options.mediaResolution,
+          backend: options.backend,
         },
         isFirstTurn ? multimodalParts : undefined
       );
@@ -128,6 +129,7 @@ export class AgenticLoop {
             model: options.model,
             thinkingLevel: options.thinkingLevel,
             mediaResolution: options.mediaResolution,
+            backend: options.backend,
           });
 
           // Add fallback response as final output

--- a/src/agentic/RunState.ts
+++ b/src/agentic/RunState.ts
@@ -38,6 +38,7 @@ export interface RunOptions {
   model?: string;
   thinkingLevel?: string;
   mediaResolution?: string;
+  backend?: 'vertex' | 'ai-studio';
 }
 
 export class RunState {

--- a/src/agentic/RunState.ts
+++ b/src/agentic/RunState.ts
@@ -5,6 +5,7 @@
 
 import { Logger } from '../utils/Logger.js';
 import { Message } from '../types/index.js';
+import { Backend } from '../types/config.js';
 
 export interface RunItem {
   type: 'message' | 'tool_call' | 'tool_result' | 'reasoning';
@@ -38,7 +39,7 @@ export interface RunOptions {
   model?: string;
   thinkingLevel?: string;
   mediaResolution?: string;
-  backend?: 'vertex' | 'ai-studio';
+  backend?: Backend;
 }
 
 export class RunState {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,29 +4,61 @@
  * Reference: https://googleapis.github.io/js-genai/release_docs/index.html
  */
 
-import { GeminiAIConfig } from '../types/index.js';
+import { GeminiAIConfig, Backend } from '../types/index.js';
 
 export function loadConfig(): GeminiAIConfig {
   const apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY;
   const projectId = process.env.GOOGLE_CLOUD_PROJECT;
   const explicitVertexMode = process.env.GOOGLE_GENAI_USE_VERTEXAI;
-  const useVertexAI = explicitVertexMode === undefined
-    ? Boolean(projectId) || !apiKey
-    : explicitVertexMode === "true";
 
-  if (useVertexAI && !projectId) {
+  // Detect which backends have credentials. When both are present, the server
+  // can route per request (the `backend` tool argument); otherwise it serves
+  // the single available backend.
+  const vertexAvailable = Boolean(projectId);
+  const aiStudioAvailable = Boolean(apiKey);
+
+  if (!vertexAvailable && !aiStudioAvailable) {
     console.error(
-      "Error: GOOGLE_CLOUD_PROJECT environment variable is required when using Vertex AI mode"
+      "Error: set GOOGLE_CLOUD_PROJECT (Vertex AI) and/or GEMINI_API_KEY/GOOGLE_API_KEY (Google AI Studio)."
     );
     process.exit(1);
   }
 
-  if (!useVertexAI && !apiKey) {
+  // Resolve the default backend: explicit override wins, else infer from creds
+  // (Vertex preferred when a project is set, matching prior behavior).
+  let defaultBackend: Backend;
+  if (explicitVertexMode === "true") {
+    defaultBackend = "vertex";
+  } else if (explicitVertexMode === "false") {
+    defaultBackend = "ai-studio";
+  } else {
+    defaultBackend = vertexAvailable ? "vertex" : "ai-studio";
+  }
+
+  if (defaultBackend === "vertex" && !vertexAvailable) {
     console.error(
-      "Error: GEMINI_API_KEY or GOOGLE_API_KEY environment variable is required when using Google AI Studio / Gemini Developer API mode"
+      "Error: GOOGLE_CLOUD_PROJECT is required when GOOGLE_GENAI_USE_VERTEXAI=true (Vertex AI mode)"
     );
     process.exit(1);
   }
+  if (defaultBackend === "ai-studio" && !aiStudioAvailable) {
+    console.error(
+      "Error: GEMINI_API_KEY or GOOGLE_API_KEY is required when GOOGLE_GENAI_USE_VERTEXAI=false (Google AI Studio mode)"
+    );
+    process.exit(1);
+  }
+
+  // Default backend first so it is the natural primary in any ordered use.
+  const availableBackends: Backend[] = [];
+  if (defaultBackend === "vertex") {
+    availableBackends.push("vertex");
+    if (aiStudioAvailable) availableBackends.push("ai-studio");
+  } else {
+    availableBackends.push("ai-studio");
+    if (vertexAvailable) availableBackends.push("vertex");
+  }
+
+  const useVertexAI = defaultBackend === "vertex";
 
   // Get location - follows gen-ai SDK standards
   // Note: @google/genai with Vertex AI mode requires location for proper authentication
@@ -78,6 +110,8 @@ export function loadConfig(): GeminiAIConfig {
     location,
     apiKey,
     useVertexAI,
+    defaultBackend,
+    availableBackends,
     model,
     temperature,
     maxTokens,

--- a/src/handlers/ImageGenerationHandler.ts
+++ b/src/handlers/ImageGenerationHandler.ts
@@ -25,6 +25,7 @@ export class ImageGenerationHandler {
       systemInstruction: input.systemInstruction,
       thinkingLevel: input.thinkingLevel,
       mediaResolution: input.mediaResolution,
+      backend: input.backend,
     });
 
     if (result.images.length === 0) {

--- a/src/handlers/MusicGenerationHandler.ts
+++ b/src/handlers/MusicGenerationHandler.ts
@@ -32,6 +32,7 @@ export class MusicGenerationHandler {
       durationSeconds: input.durationSeconds,
       bpm: input.bpm,
       intensity: input.intensity,
+      backend: input.backend,
     });
 
     if (result.audios.length === 0) {

--- a/src/handlers/QueryHandler.ts
+++ b/src/handlers/QueryHandler.ts
@@ -60,6 +60,7 @@ export class QueryHandler {
           model: input.model,
           thinkingLevel: input.thinkingLevel,
           mediaResolution: input.mediaResolution,
+          backend: input.backend,
         },
         input.parts // Pass multimodal parts
       );

--- a/src/handlers/SpeechGenerationHandler.ts
+++ b/src/handlers/SpeechGenerationHandler.ts
@@ -28,6 +28,7 @@ export class SpeechGenerationHandler {
       voiceName: input.voiceName,
       languageCode: input.languageCode,
       speakers: input.speakers,
+      backend: input.backend,
     });
 
     if (result.audios.length === 0) {

--- a/src/handlers/VideoGenerationHandler.test.ts
+++ b/src/handlers/VideoGenerationHandler.test.ts
@@ -235,6 +235,20 @@ describe('GeminiAIMCPServer generate_video wiring', () => {
     expect(mockVideoGenHandle).toHaveBeenCalledWith({ prompt: 'a dancing cat' });
   });
 
+  it('strips the backend argument in single-backend deployments', async () => {
+    // createTestConfig is Vertex-only (useVertexAI: true, no availableBackends).
+    // A backend arg is not advertised and must be ignored, so the request still
+    // parses (it is not rejected by the Vertex-only model/backend enum).
+    await callHandler({
+      params: {
+        name: 'generate_video',
+        arguments: { prompt: 'a dancing cat', backend: 'ai-studio' },
+      },
+    });
+
+    expect(mockVideoGenHandle).toHaveBeenCalledWith({ prompt: 'a dancing cat' });
+  });
+
   it('validates generate_video calls against Gemini Developer API mode', async () => {
     const aiStudioServer = new GeminiAIMCPServer(createTestConfig({ useVertexAI: false }));
     const handlers = getHandlers((aiStudioServer as any).server);

--- a/src/handlers/VideoGenerationHandler.ts
+++ b/src/handlers/VideoGenerationHandler.ts
@@ -34,6 +34,7 @@ export class VideoGenerationHandler {
       videoPath: input.videoPath,
       compressionQuality: input.compressionQuality,
       resizeMode: input.resizeMode,
+      backend: input.backend,
     });
 
     return {

--- a/src/schemas/index.test.ts
+++ b/src/schemas/index.test.ts
@@ -247,13 +247,13 @@ describe('VideoGenerationSchema Vertex-only output controls', () => {
     expect(() => GeminiApiVideoSchema.parse({
       prompt: 'compressed video',
       compressionQuality: 'lossless',
-    })).toThrow(/compressionQuality is only supported in Vertex AI mode/);
+    })).toThrow(/compressionQuality is only supported by the Vertex AI backend/);
 
     expect(() => GeminiApiVideoSchema.parse({
       prompt: 'animate this frame',
       imagePath: '/tmp/frame.png',
       resizeMode: 'crop',
-    })).toThrow(/resizeMode is only supported in Vertex AI mode/);
+    })).toThrow(/resizeMode is only supported by the Vertex AI backend/);
   });
 });
 
@@ -316,6 +316,53 @@ describe('VideoGenerationSchema Gemini Developer API compatibility', () => {
       imagePath: '/tmp/frame.png',
       personGeneration: 'allow_all',
     })).toThrow(/allow_adult/);
+  });
+});
+
+describe('buildVideoGenerationSchema dual-backend mode', () => {
+  const DualSchema = buildVideoGenerationSchema(true, ['vertex', 'ai-studio']);
+
+  it('accepts both Vertex (-001) and AI Studio (-preview) models when routed correctly', () => {
+    expect(DualSchema.parse({ prompt: 'x', model: 'veo-3.1-generate-001' }).model)
+      .toBe('veo-3.1-generate-001');
+    expect(DualSchema.parse({ prompt: 'x', backend: 'ai-studio', model: 'veo-3.1-generate-preview' }).model)
+      .toBe('veo-3.1-generate-preview');
+  });
+
+  it('rejects a model that does not match the selected backend', () => {
+    // default backend is vertex; a -preview model belongs to ai-studio
+    expect(() => DualSchema.parse({ prompt: 'x', model: 'veo-3.1-generate-preview' }))
+      .toThrow(/does not match the selected backend/);
+    expect(() => DualSchema.parse({ prompt: 'x', backend: 'vertex', model: 'veo-3.1-generate-preview' }))
+      .toThrow(/does not match the selected backend/);
+  });
+
+  it('gates Vertex-only fields by the selected backend', () => {
+    expect(() => DualSchema.parse({
+      prompt: 'x', backend: 'ai-studio', model: 'veo-3.1-generate-preview', seed: 1,
+    })).toThrow(/seed/);
+    // vertex is the default backend, so seed is allowed without a backend arg
+    expect(DualSchema.parse({ prompt: 'x', seed: 1 }).seed).toBe(1);
+  });
+
+  it('rejects a backend value that is not configured', () => {
+    const VertexOnly = buildVideoGenerationSchema(true, ['vertex']);
+    expect(() => VertexOnly.parse({ prompt: 'x', backend: 'ai-studio' })).toThrow();
+  });
+});
+
+describe('buildMusicGenerationSchema dual-backend mode', () => {
+  const DualMusic = buildMusicGenerationSchema(true, ['vertex', 'ai-studio']);
+
+  it('allows WAV only on the ai-studio backend for lyria-3-pro-preview', () => {
+    expect(DualMusic.parse({
+      prompt: 'song', backend: 'ai-studio', model: 'lyria-3-pro-preview', outputMimeType: 'audio/wav',
+    }).outputMimeType).toBe('audio/wav');
+
+    // vertex backend rejects wav
+    expect(() => DualMusic.parse({
+      prompt: 'song', backend: 'vertex', model: 'lyria-3-pro-preview', outputMimeType: 'audio/wav',
+    })).toThrow(/audio\/mp3/);
   });
 });
 

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from "zod";
+import { Backend } from "../types/config.js";
 
 export const GEMINI_IMAGE_INPUT_FILE_TYPES = 'PNG (.png), JPEG (.jpg/.jpeg), WEBP (.webp), HEIC (.heic), HEIF (.heif)';
 export const VEO_IMAGE_INPUT_FILE_TYPES = 'PNG (.png), JPEG (.jpg/.jpeg), WEBP (.webp)';
@@ -55,6 +56,8 @@ export const QuerySchema = z.object({
   prompt: z.string().describe("The text prompt to send to Vertex AI"),
   sessionId: z.string().optional().describe("Optional conversation session ID for multi-turn conversations"),
   model: z.string().optional().describe("Optional model override (e.g., gemini-3.5-flash, gemini-3.1-pro-preview, gemini-3.1-flash-lite, gemini-3.1-pro-preview-customtools)"),
+  backend: z.enum(['vertex', 'ai-studio']).optional()
+    .describe("Optional backend override ('vertex' | 'ai-studio'); defaults to the server's configured backend"),
   thinkingLevel: z.enum(['minimal', 'low', 'medium', 'high', 'MINIMAL', 'LOW', 'MEDIUM', 'HIGH']).optional()
     .describe("Optional Gemini 3 thinking level override"),
   mediaResolution: z.enum(['low', 'medium', 'high', 'LOW', 'MEDIUM', 'HIGH']).optional()
@@ -86,6 +89,8 @@ export const ImageGenerationSchema = z.object({
   prompt: z.string().describe("Image generation prompt"),
   model: z.enum(ALLOWED_IMAGE_MODELS).optional()
     .describe("Image model (default: gemini-3-pro-image)"),
+  backend: z.enum(['vertex', 'ai-studio']).optional()
+    .describe("Optional backend override ('vertex' | 'ai-studio'); defaults to the server's configured backend"),
   aspectRatio: z.enum(ALLOWED_IMAGE_ASPECT_RATIOS).optional()
     .describe("Aspect ratio (default: 1:1; 1:4, 1:8, 4:1, and 8:1 require gemini-3.1-flash-image)"),
   imageSize: z.enum(['0.5K', '1K', '2K', '4K']).optional()
@@ -164,6 +169,8 @@ export const SpeechGenerationSchema = z.object({
   prompt: z.string().describe("Text or transcript to synthesize as speech. Gemini TTS is text-only input; audio/image/video reference files are not accepted."),
   model: z.enum(ALLOWED_SPEECH_MODELS).optional()
     .describe("Speech model (default: gemini-3.1-flash-tts-preview)"),
+  backend: z.enum(['vertex', 'ai-studio']).optional()
+    .describe("Optional backend override ('vertex' | 'ai-studio'); defaults to the server's configured backend"),
   voiceName: z.string().min(1).optional()
     .describe("Prebuilt voice name for single-speaker TTS (default: Kore)"),
   languageCode: z.string().min(2).optional()
@@ -195,15 +202,20 @@ export function getAllowedMusicOutputMimeTypes(useVertexAI: boolean = true): rea
   return useVertexAI ? ['audio/mp3'] : ['audio/mp3', 'audio/wav'];
 }
 
-export function buildMusicGenerationSchema(useVertexAI: boolean = true) {
+export function buildMusicGenerationSchema(
+  useVertexAI: boolean = true,
+  availableBackends: Backend[] = [useVertexAI ? 'vertex' : 'ai-studio'],
+) {
+  const defaultBackend: Backend = useVertexAI ? 'vertex' : 'ai-studio';
+  const isVertex = (data: { backend?: Backend }): boolean => (data.backend ?? defaultBackend) === 'vertex';
   return z.object({
     prompt: z.string().describe("Music generation prompt"),
+    backend: z.enum(availableBackends as [Backend, ...Backend[]]).optional()
+      .describe(`Backend for this request (default: ${defaultBackend}; available: ${availableBackends.join(', ')}). Vertex AI supports audio/mp3 only; Google AI Studio adds audio/wav for lyria-3-pro-preview.`),
     model: z.enum(ALLOWED_MUSIC_MODELS).optional()
       .describe("Music model (default: lyria-3-clip-preview)"),
     outputMimeType: z.enum(['audio/mp3', 'audio/wav']).optional()
-      .describe(useVertexAI
-        ? "Optional output MIME type; Vertex AI Lyria 3 model card supports audio/mp3 only"
-        : "Optional output MIME type; Gemini API defaults to audio/mp3 and supports audio/wav only with lyria-3-pro-preview"),
+      .describe("Optional output MIME type. Vertex AI supports audio/mp3 only; Google AI Studio supports audio/wav for lyria-3-pro-preview."),
     imagePaths: z.array(GeminiImageInputPathSchema).max(10).optional()
       .describe(`Optional local image paths to use as multimodal Lyria music generation inputs (max 10). Supported Gemini image input file types: ${GEMINI_IMAGE_INPUT_FILE_TYPES}. Audio/video reference files are not accepted by Lyria 3.`),
     lyrics: z.string().optional()
@@ -227,22 +239,36 @@ export function buildMusicGenerationSchema(useVertexAI: boolean = true) {
     (data) => !data.instrumental || (!data.lyrics && !data.vocalStyle),
     { message: "instrumental cannot be combined with lyrics or vocalStyle" }
   ).refine(
-    (data) => !useVertexAI || data.outputMimeType === undefined || data.outputMimeType === 'audio/mp3',
-    { message: "Vertex AI Lyria 3 supports outputMimeType='audio/mp3' only" }
+    (data) => !isVertex(data) || data.outputMimeType === undefined || data.outputMimeType === 'audio/mp3',
+    { message: "the Vertex AI backend supports outputMimeType='audio/mp3' only for Lyria 3" }
   ).refine(
-    (data) => useVertexAI || data.outputMimeType !== 'audio/wav' || data.model === 'lyria-3-pro-preview',
-    { message: "outputMimeType='audio/wav' requires model='lyria-3-pro-preview' in Gemini API mode" }
+    (data) => isVertex(data) || data.outputMimeType !== 'audio/wav' || data.model === 'lyria-3-pro-preview',
+    { message: "outputMimeType='audio/wav' requires model='lyria-3-pro-preview' on the Google AI Studio backend" }
   );
 }
 
 export const MusicGenerationSchema = buildMusicGenerationSchema(true);
 
-export function buildVideoGenerationSchema(useVertexAI: boolean = true) {
-  const allowedVideoModels = useVertexAI ? ALLOWED_VERTEX_VIDEO_MODELS : ALLOWED_GEMINI_API_VIDEO_MODELS;
-  const maxVideoCount = useVertexAI ? 4 : 1;
+export function buildVideoGenerationSchema(
+  useVertexAI: boolean = true,
+  availableBackends: Backend[] = [useVertexAI ? 'vertex' : 'ai-studio'],
+) {
+  const defaultBackend: Backend = useVertexAI ? 'vertex' : 'ai-studio';
+  const dual = availableBackends.length > 1;
+  const allowedVideoModels = (dual
+    ? [...ALLOWED_VERTEX_VIDEO_MODELS, ...ALLOWED_GEMINI_API_VIDEO_MODELS]
+    : (useVertexAI ? ALLOWED_VERTEX_VIDEO_MODELS : ALLOWED_GEMINI_API_VIDEO_MODELS)
+  ) as [string, ...string[]];
+  const maxVideoCount = dual ? 4 : (useVertexAI ? 4 : 1);
+  const effBackend = (data: { backend?: Backend }): Backend => data.backend ?? defaultBackend;
+  const isVertex = (data: { backend?: Backend }): boolean => effBackend(data) === 'vertex';
+  const modelsForBackend = (b: Backend): readonly string[] =>
+    b === 'vertex' ? ALLOWED_VERTEX_VIDEO_MODELS : ALLOWED_GEMINI_API_VIDEO_MODELS;
 
   return z.object({
     prompt: z.string().describe("Video generation prompt"),
+    backend: z.enum(availableBackends as [Backend, ...Backend[]]).optional()
+      .describe(`Backend for this request (default: ${defaultBackend}; available: ${availableBackends.join(', ')}). Vertex AI uses '-001' model IDs and Vertex-only controls (seed, generateAudio, numberOfVideos>1, compressionQuality, resizeMode); Google AI Studio uses '-preview' IDs.`),
     model: z.enum(allowedVideoModels).optional()
       .describe(`Video model (default: ${getDefaultVideoModel(useVertexAI)})`),
     aspectRatio: z.enum(['16:9', '9:16']).optional()
@@ -276,6 +302,9 @@ export function buildVideoGenerationSchema(useVertexAI: boolean = true) {
     resizeMode: z.enum(['crop', 'pad']).optional()
       .describe("How the input image is fit to the target aspect ratio for image-to-video (Vertex AI only; requires imagePath): 'crop' or 'pad' (default pad)"),
   }).strict().refine(
+    (data) => !data.model || modelsForBackend(effBackend(data)).includes(data.model),
+    { message: "model does not match the selected backend; Vertex AI uses '-001' model IDs and Google AI Studio uses '-preview' model IDs" }
+  ).refine(
     (data) => {
       if (data.resolution === '1080p' || data.resolution === '4k') {
         return data.durationSeconds === undefined || data.durationSeconds === '8';
@@ -352,17 +381,17 @@ export function buildVideoGenerationSchema(useVertexAI: boolean = true) {
     (data) => data.model !== 'veo-3.1-lite-generate-preview' || data.resolution !== '4k',
     { message: "resolution '4k' is not supported by model='veo-3.1-lite-generate-preview'" }
   ).refine(
-    (data) => useVertexAI || data.generateAudio === undefined,
-    { message: "generateAudio is always on and cannot be configured in Gemini Developer API mode" }
+    (data) => isVertex(data) || data.generateAudio === undefined,
+    { message: "generateAudio is always on and cannot be configured for the Google AI Studio backend" }
   ).refine(
-    (data) => useVertexAI || data.seed === undefined,
-    { message: "seed is not supported by @google/genai generateVideos in Gemini Developer API mode" }
+    (data) => isVertex(data) || data.seed === undefined,
+    { message: "seed is not supported by @google/genai generateVideos for the Google AI Studio backend" }
   ).refine(
-    (data) => useVertexAI || data.numberOfVideos === undefined || data.numberOfVideos === 1,
-    { message: "Gemini Developer API Veo 3.1 returns a single video; omit numberOfVideos or set it to 1" }
+    (data) => isVertex(data) || data.numberOfVideos === undefined || data.numberOfVideos === 1,
+    { message: "Google AI Studio Veo 3.1 returns a single video; omit numberOfVideos or set it to 1" }
   ).refine(
     (data) => {
-      if (useVertexAI || !data.personGeneration) {
+      if (isVertex(data) || !data.personGeneration) {
         return true;
       }
       const usesImageMode = !!data.imagePath || !!data.lastFramePath || !!data.referenceImagePaths?.length;
@@ -373,11 +402,11 @@ export function buildVideoGenerationSchema(useVertexAI: boolean = true) {
     },
     { message: "Gemini Developer API Veo 3.1 uses personGeneration='allow_all' for text/video extension and 'allow_adult' for image/reference modes" }
   ).refine(
-    (data) => useVertexAI || data.compressionQuality === undefined,
-    { message: "compressionQuality is only supported in Vertex AI mode" }
+    (data) => isVertex(data) || data.compressionQuality === undefined,
+    { message: "compressionQuality is only supported by the Vertex AI backend" }
   ).refine(
-    (data) => useVertexAI || data.resizeMode === undefined,
-    { message: "resizeMode is only supported in Vertex AI mode" }
+    (data) => isVertex(data) || data.resizeMode === undefined,
+    { message: "resizeMode is only supported by the Vertex AI backend" }
   ).refine(
     (data) => !data.resizeMode || !!data.imagePath,
     { message: "resizeMode requires imagePath (image-to-video mode)" }

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -53,7 +53,7 @@ const MultimodalPartSchema = z.object({
 });
 
 export const QuerySchema = z.object({
-  prompt: z.string().describe("The text prompt to send to Vertex AI"),
+  prompt: z.string().describe("The text prompt to send to the model"),
   sessionId: z.string().optional().describe("Optional conversation session ID for multi-turn conversations"),
   model: z.string().optional().describe("Optional model override (e.g., gemini-3.5-flash, gemini-3.1-pro-preview, gemini-3.1-flash-lite, gemini-3.1-pro-preview-customtools)"),
   backend: z.enum(['vertex', 'ai-studio']).optional()

--- a/src/server/GeminiAIMCPServer.ts
+++ b/src/server/GeminiAIMCPServer.ts
@@ -602,6 +602,14 @@ export class GeminiAIMCPServer {
       const toolName = request.params.name;
       const args = request.params.arguments || {};
 
+      // The `backend` selector is only advertised when multiple backends are
+      // configured. In single-backend deployments, ignore any `backend` arg so
+      // runtime behavior matches the advertised tool contract.
+      const configuredBackends = this.config.availableBackends ?? [this.config.useVertexAI ? 'vertex' : 'ai-studio'];
+      if (configuredBackends.length < 2 && args && typeof args === 'object') {
+        delete (args as Record<string, unknown>).backend;
+      }
+
       try {
         switch (toolName) {
           case "query": {

--- a/src/server/GeminiAIMCPServer.ts
+++ b/src/server/GeminiAIMCPServer.ts
@@ -136,13 +136,25 @@ export class GeminiAIMCPServer {
   private setupHandlers(): void {
     // List available tools
     this.server.setRequestHandler(ListToolsRequestSchema, async () => {
-      const videoModelEnum = getAllowedVideoModels(this.config.useVertexAI);
+      const availableBackends = this.config.availableBackends ?? [this.config.useVertexAI ? 'vertex' : 'ai-studio'];
+      const defaultBackend = this.config.defaultBackend ?? (this.config.useVertexAI ? 'vertex' : 'ai-studio');
+      const dual = availableBackends.length > 1;
+      const backendProp = {
+        type: "string",
+        enum: availableBackends,
+        description: `Backend for this request (default: ${defaultBackend}; available: ${availableBackends.join(', ')}). Vertex AI uses '-001' video model IDs and Vertex-only controls; Google AI Studio uses '-preview' IDs.`,
+      };
+      const videoModelEnum = dual
+        ? [...getAllowedVideoModels(true), ...getAllowedVideoModels(false)]
+        : getAllowedVideoModels(this.config.useVertexAI);
       const defaultVideoModel = getDefaultVideoModel(this.config.useVertexAI);
-      const maxVideoCount = this.config.useVertexAI ? 4 : 1;
-      const musicOutputMimeTypes = getAllowedMusicOutputMimeTypes(this.config.useVertexAI);
-      const musicOutputMimeDescription = this.config.useVertexAI
-        ? "Optional output MIME type; Vertex AI Lyria 3 model card supports audio/mp3 only"
-        : "Optional output MIME type; Gemini API/AI Studio defaults to audio/mp3 and supports audio/wav only with lyria-3-pro-preview";
+      const maxVideoCount = dual ? 4 : (this.config.useVertexAI ? 4 : 1);
+      const musicOutputMimeTypes = dual ? ['audio/mp3', 'audio/wav'] : getAllowedMusicOutputMimeTypes(this.config.useVertexAI);
+      const musicOutputMimeDescription = dual
+        ? "Optional output MIME type. Vertex AI supports audio/mp3 only; Google AI Studio supports audio/wav for lyria-3-pro-preview."
+        : (this.config.useVertexAI
+          ? "Optional output MIME type; Vertex AI Lyria 3 model card supports audio/mp3 only"
+          : "Optional output MIME type; Gemini API/AI Studio defaults to audio/mp3 and supports audio/wav only with lyria-3-pro-preview");
 
       const tools = [
         {
@@ -565,6 +577,23 @@ export class GeminiAIMCPServer {
         },
       ];
 
+      // When more than one backend is configured, advertise the per-request
+      // `backend` selector on every generation tool so callers can switch.
+      if (dual) {
+        const backendTools = new Set([
+          "query",
+          "generate_image",
+          "generate_speech",
+          "generate_video",
+          "generate_music",
+        ]);
+        for (const tool of tools) {
+          if (backendTools.has(tool.name)) {
+            (tool.inputSchema.properties as Record<string, unknown>).backend = backendProp;
+          }
+        }
+      }
+
       return { tools };
     });
 
@@ -601,12 +630,12 @@ export class GeminiAIMCPServer {
           }
 
           case "generate_music": {
-            const input = buildMusicGenerationSchema(this.config.useVertexAI).parse(args);
+            const input = buildMusicGenerationSchema(this.config.useVertexAI, this.config.availableBackends).parse(args);
             return await this.musicGenerationHandler.handle(input);
           }
 
           case "generate_video": {
-            const input = buildVideoGenerationSchema(this.config.useVertexAI).parse(args);
+            const input = buildVideoGenerationSchema(this.config.useVertexAI, this.config.availableBackends).parse(args);
             return await this.videoGenerationHandler.handle(input);
           }
 

--- a/src/services/GeminiAIService.test.ts
+++ b/src/services/GeminiAIService.test.ts
@@ -199,6 +199,55 @@ describe('generated audio output config', () => {
   });
 });
 
+describe('backend availability detection', () => {
+  it('exposes both backends when both credentials are present', async () => {
+    const savedKey = process.env.GEMINI_API_KEY;
+    const savedGoogleKey = process.env.GOOGLE_API_KEY;
+    const savedProject = process.env.GOOGLE_CLOUD_PROJECT;
+    const savedUseVertex = process.env.GOOGLE_GENAI_USE_VERTEXAI;
+    process.env.GEMINI_API_KEY = 'test-key';
+    process.env.GOOGLE_CLOUD_PROJECT = 'test-project';
+    delete process.env.GOOGLE_GENAI_USE_VERTEXAI;
+
+    try {
+      const { loadConfig } = await import('../config/index.js');
+      const config = loadConfig();
+      expect(config.availableBackends).toContain('vertex');
+      expect(config.availableBackends).toContain('ai-studio');
+      expect(config.availableBackends).toHaveLength(2);
+      // project present and no explicit override -> vertex is the default
+      expect(config.defaultBackend).toBe('vertex');
+      expect(config.useVertexAI).toBe(true);
+    } finally {
+      if (savedKey !== undefined) process.env.GEMINI_API_KEY = savedKey; else delete process.env.GEMINI_API_KEY;
+      if (savedGoogleKey !== undefined) process.env.GOOGLE_API_KEY = savedGoogleKey; else delete process.env.GOOGLE_API_KEY;
+      if (savedProject !== undefined) process.env.GOOGLE_CLOUD_PROJECT = savedProject; else delete process.env.GOOGLE_CLOUD_PROJECT;
+      if (savedUseVertex !== undefined) process.env.GOOGLE_GENAI_USE_VERTEXAI = savedUseVertex; else delete process.env.GOOGLE_GENAI_USE_VERTEXAI;
+    }
+  });
+
+  it('explicit GOOGLE_GENAI_USE_VERTEXAI=false defaults to ai-studio even with a project set', async () => {
+    const savedKey = process.env.GEMINI_API_KEY;
+    const savedProject = process.env.GOOGLE_CLOUD_PROJECT;
+    const savedUseVertex = process.env.GOOGLE_GENAI_USE_VERTEXAI;
+    process.env.GEMINI_API_KEY = 'test-key';
+    process.env.GOOGLE_CLOUD_PROJECT = 'test-project';
+    process.env.GOOGLE_GENAI_USE_VERTEXAI = 'false';
+
+    try {
+      const { loadConfig } = await import('../config/index.js');
+      const config = loadConfig();
+      expect(config.defaultBackend).toBe('ai-studio');
+      expect(config.availableBackends).toContain('vertex');
+      expect(config.availableBackends[0]).toBe('ai-studio');
+    } finally {
+      if (savedKey !== undefined) process.env.GEMINI_API_KEY = savedKey; else delete process.env.GEMINI_API_KEY;
+      if (savedProject !== undefined) process.env.GOOGLE_CLOUD_PROJECT = savedProject; else delete process.env.GOOGLE_CLOUD_PROJECT;
+      if (savedUseVertex !== undefined) process.env.GOOGLE_GENAI_USE_VERTEXAI = savedUseVertex; else delete process.env.GOOGLE_GENAI_USE_VERTEXAI;
+    }
+  });
+});
+
 describe('generateVideo backend compatibility', () => {
   function createServiceConfig(overrides: Record<string, unknown> = {}) {
     return {
@@ -227,9 +276,10 @@ describe('generateVideo backend compatibility', () => {
     const generateVideos = vi.fn().mockResolvedValue({
       name: 'projects/test-project/locations/us-central1/operations/op-123',
     });
-    (service as any).client = {
+    (service as any).clientFor = () => ({
       models: { generateVideos },
-    };
+      operations: {},
+    });
     return generateVideos;
   }
 
@@ -295,6 +345,46 @@ describe('generateVideo backend compatibility', () => {
     const params = generateVideos.mock.calls[0][0];
     expect(params.config).not.toHaveProperty('compressionQuality');
     expect(params.config).not.toHaveProperty('resizeMode');
+  });
+
+  it('routes per-request backend override (default vertex, request ai-studio)', async () => {
+    // Default backend is vertex, but the request selects ai-studio.
+    const service = new GeminiAIService(createServiceConfig({
+      defaultBackend: 'vertex',
+      availableBackends: ['vertex', 'ai-studio'],
+    }));
+    const generateVideos = stubGenerateVideos(service);
+
+    await service.generateVideo('a cinematic ocean shot', {
+      backend: 'ai-studio',
+      seed: 123,
+      compressionQuality: 'lossless',
+    });
+
+    const params = generateVideos.mock.calls[0][0];
+    // ai-studio backend default model + Vertex-only fields omitted
+    expect(params.model).toBe('veo-3.1-fast-generate-preview');
+    expect(params.config).not.toHaveProperty('seed');
+    expect(params.config).not.toHaveProperty('compressionQuality');
+  });
+
+  it('routes per-request backend override (default ai-studio, request vertex)', async () => {
+    const service = new GeminiAIService(createServiceConfig({
+      useVertexAI: false,
+      defaultBackend: 'ai-studio',
+      availableBackends: ['ai-studio', 'vertex'],
+    }));
+    const generateVideos = stubGenerateVideos(service);
+
+    await service.generateVideo('a cinematic ocean shot', {
+      backend: 'vertex',
+      seed: 123,
+    });
+
+    const params = generateVideos.mock.calls[0][0];
+    expect(params.model).toBe('veo-3.1-fast-generate-001');
+    expect(params.config.seed).toBe(123);
+    expect(params.config.generateAudio).toBe(true);
   });
 });
 

--- a/src/services/GeminiAIService.test.ts
+++ b/src/services/GeminiAIService.test.ts
@@ -239,7 +239,7 @@ describe('backend availability detection', () => {
       const config = loadConfig();
       expect(config.defaultBackend).toBe('ai-studio');
       expect(config.availableBackends).toContain('vertex');
-      expect(config.availableBackends[0]).toBe('ai-studio');
+      expect(config.availableBackends?.[0]).toBe('ai-studio');
     } finally {
       if (savedKey !== undefined) process.env.GEMINI_API_KEY = savedKey; else delete process.env.GEMINI_API_KEY;
       if (savedProject !== undefined) process.env.GOOGLE_CLOUD_PROJECT = savedProject; else delete process.env.GOOGLE_CLOUD_PROJECT;

--- a/src/services/GeminiAIService.ts
+++ b/src/services/GeminiAIService.ts
@@ -9,7 +9,7 @@ import { extname, resolve as resolvePath, sep as pathSep } from "node:path";
 
 // Re-export ThinkingLevel for consumers
 export { ThinkingLevel } from "@google/genai";
-import { GeminiAIConfig, MultimodalPart, isSupportedMimeType } from '../types/index.js';
+import { GeminiAIConfig, Backend, MultimodalPart, isSupportedMimeType } from '../types/index.js';
 import { validateSecureUrl } from '../utils/urlSecurity.js';
 import { validateMultimodalFile } from '../utils/fileSecurity.js';
 import { resolveOutputDirs } from '../utils/generatedFileSaver.js';
@@ -24,6 +24,7 @@ export interface ImageGenerationOptions {
   systemInstruction?: string;
   thinkingLevel?: ThinkingLevel | string;
   mediaResolution?: string;
+  backend?: Backend;
 }
 
 export interface GeneratedImage {
@@ -48,6 +49,7 @@ export interface VideoGenerationOptions {
   videoPath?: string;
   compressionQuality?: string;
   resizeMode?: string;
+  backend?: Backend;
 }
 
 export interface GeneratedVideo {
@@ -65,6 +67,7 @@ export interface SpeechGenerationOptions {
   voiceName?: string;
   languageCode?: string;
   speakers?: SpeechSpeakerOptions[];
+  backend?: Backend;
 }
 
 export interface MusicGenerationOptions {
@@ -78,6 +81,7 @@ export interface MusicGenerationOptions {
   durationSeconds?: number;
   bpm?: number;
   intensity?: string;
+  backend?: Backend;
 }
 
 export interface GeneratedAudio {
@@ -106,31 +110,65 @@ export interface QueryOptions {
    * When provided, overrides the ENV-configured model.
    */
   model?: string;
+  /**
+   * Optional backend override ('vertex' | 'ai-studio') for per-request routing.
+   * Defaults to the server's configured default backend.
+   */
+  backend?: Backend;
 }
 
 export class GeminiAIService {
-  private client: GoogleGenAI;
+  private clients = new Map<Backend, GoogleGenAI>();
   private config: GeminiAIConfig;
-  private pendingVideoOps = new Map<string, any>();
+  private pendingVideoOps = new Map<string, { operation: any; backend: Backend }>();
   private extraSafeDirectories: string[];
 
   constructor(config: GeminiAIConfig) {
     this.config = config;
-    this.client = config.useVertexAI
-      ? new GoogleGenAI({
-          vertexai: true,
-          project: config.projectId,
-          location: config.location,
-        })
-      : new GoogleGenAI({
-          apiKey: config.apiKey,
-        });
 
     // Auto-allow this server's own generated-output directories so users can
     // round-trip generated files (e.g. feed a generated image back into query).
     const outputs = resolveOutputDirs(config);
     this.extraSafeDirectories = [outputs.image, outputs.video, outputs.speech, outputs.music]
       .map(d => resolvePath(d));
+  }
+
+  /** Resolve the effective backend for a request (explicit override or default). */
+  private resolveBackend(backend?: Backend): Backend {
+    return backend ?? this.config.defaultBackend ?? (this.config.useVertexAI ? 'vertex' : 'ai-studio');
+  }
+
+  /**
+   * Lazily build and cache a GoogleGenAI client for the given backend.
+   * Throws a clear error when the backend's credentials are not configured.
+   */
+  private clientFor(backend: Backend): GoogleGenAI {
+    const existing = this.clients.get(backend);
+    if (existing) return existing;
+
+    let client: GoogleGenAI;
+    if (backend === 'vertex') {
+      if (!this.config.projectId) {
+        throw new Error(
+          "Vertex AI backend requested but GOOGLE_CLOUD_PROJECT is not configured"
+        );
+      }
+      client = new GoogleGenAI({
+        vertexai: true,
+        project: this.config.projectId,
+        location: this.config.location,
+      });
+    } else {
+      if (!this.config.apiKey) {
+        throw new Error(
+          "Google AI Studio backend requested but GEMINI_API_KEY/GOOGLE_API_KEY is not configured"
+        );
+      }
+      client = new GoogleGenAI({ apiKey: this.config.apiKey });
+    }
+
+    this.clients.set(backend, client);
+    return client;
   }
 
   private isInSelfManagedDir(absolutePath: string): boolean {
@@ -197,7 +235,8 @@ export class GeminiAIService {
       // Build content parts
       const contents = await this.buildContents(prompt, multimodalParts);
 
-      const response = await this.client.models.generateContent({
+      const client = this.clientFor(this.resolveBackend(options.backend));
+      const response = await client.models.generateContent({
         model: effectiveModel,
         contents,
         config,
@@ -437,7 +476,8 @@ export class GeminiAIService {
       config.mediaResolution = mediaResolution;
     }
 
-    const response = await this.client.models.generateContent({
+    const client = this.clientFor(this.resolveBackend(options.backend));
+    const response = await client.models.generateContent({
       model,
       contents,
       config,
@@ -478,7 +518,8 @@ export class GeminiAIService {
       };
     }
 
-    const response = await this.client.models.generateContent({
+    const client = this.clientFor(this.resolveBackend(options.backend));
+    const response = await client.models.generateContent({
       model,
       contents: prompt,
       config: {
@@ -506,7 +547,8 @@ export class GeminiAIService {
       config.responseMimeType = options.outputMimeType;
     }
 
-    const response = await this.client.models.generateContent({
+    const client = this.clientFor(this.resolveBackend(options.backend));
+    const response = await client.models.generateContent({
       model,
       contents: this.buildContentsWithInlineFiles(
         this.buildMusicPrompt(prompt, options),
@@ -672,7 +714,10 @@ export class GeminiAIService {
     prompt: string,
     options: VideoGenerationOptions = {}
   ): Promise<{ operationId: string }> {
-    const model = options.model || getDefaultVideoModel(this.config.useVertexAI);
+    const backend = this.resolveBackend(options.backend);
+    const useVertex = backend === 'vertex';
+    const client = this.clientFor(backend);
+    const model = options.model || getDefaultVideoModel(useVertex);
 
     // Build request parameters
     const params: any = {
@@ -689,7 +734,7 @@ export class GeminiAIService {
       },
     };
 
-    if (this.config.useVertexAI) {
+    if (useVertex) {
       params.config.generateAudio = options.generateAudio ?? true;
       params.config.seed = options.seed;
       if (options.compressionQuality) {
@@ -726,15 +771,15 @@ export class GeminiAIService {
     }
 
     // Start async operation
-    const operation = await this.client.models.generateVideos(params);
+    const operation = await client.models.generateVideos(params);
 
     // Extract UUID from operation name for a cleaner external ID
     // Format: "projects/{project}/locations/{location}/publishers/.../operations/{uuid}"
     const fullName = operation.name || '';
     const operationId = fullName.split('/').pop() || fullName;
 
-    // Cache the full operation object for polling (SDK requires the actual instance)
-    this.pendingVideoOps.set(operationId, operation);
+    // Cache the operation with its backend (polling must use the same client/backend).
+    this.pendingVideoOps.set(operationId, { operation, backend });
 
     return { operationId };
   }
@@ -753,18 +798,20 @@ export class GeminiAIService {
     operationId: string
   ): Promise<{ done: boolean; videos?: GeneratedVideo[]; error?: string }> {
     // Retrieve cached operation object (SDK requires actual operation instance for polling)
-    const cachedOp = this.pendingVideoOps.get(operationId);
-    if (!cachedOp) {
+    const cached = this.pendingVideoOps.get(operationId);
+    if (!cached) {
       return { done: true, error: `Unknown operation: ${operationId}. Operation may have been created in a previous server session.` };
     }
 
-    const operation = await this.client.operations.getVideosOperation({
-      operation: cachedOp,
+    // Poll on the same backend that created the operation.
+    const client = this.clientFor(cached.backend);
+    const operation = await client.operations.getVideosOperation({
+      operation: cached.operation,
     });
 
     if (!operation.done) {
       // Update cached operation with latest state for next poll
-      this.pendingVideoOps.set(operationId, operation);
+      this.pendingVideoOps.set(operationId, { operation, backend: cached.backend });
       return { done: false };
     }
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -5,7 +5,7 @@
 /**
  * Backend that fulfills a generation request.
  * - 'vertex': Vertex AI (requires GOOGLE_CLOUD_PROJECT)
- * - 'ai-studio': Google AI Studio / Gemini Developer API (requires GEMINI_API_KEY)
+ * - 'ai-studio': Google AI Studio / Gemini Developer API (requires GEMINI_API_KEY or GOOGLE_API_KEY)
  */
 export type Backend = 'vertex' | 'ai-studio';
 
@@ -15,10 +15,10 @@ export interface GeminiAIConfig {
   apiKey?: string;
   /** True when the default backend is Vertex AI. Kept for backward compatibility. */
   useVertexAI: boolean;
-  /** Backend used when a request does not specify one. */
-  defaultBackend: Backend;
-  /** Backends that have credentials configured and can serve requests. */
-  availableBackends: Backend[];
+  /** Backend used when a request does not specify one. Populated by loadConfig; consumers should fall back to useVertexAI when absent. */
+  defaultBackend?: Backend;
+  /** Backends that have credentials configured and can serve requests. Populated by loadConfig; consumers should fall back to [useVertexAI ? 'vertex' : 'ai-studio'] when absent. */
+  availableBackends?: Backend[];
   model: string;
   temperature: number;
   maxTokens: number;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -2,11 +2,23 @@
  * Configuration types for Gemini AI MCP Server
  */
 
+/**
+ * Backend that fulfills a generation request.
+ * - 'vertex': Vertex AI (requires GOOGLE_CLOUD_PROJECT)
+ * - 'ai-studio': Google AI Studio / Gemini Developer API (requires GEMINI_API_KEY)
+ */
+export type Backend = 'vertex' | 'ai-studio';
+
 export interface GeminiAIConfig {
   projectId?: string;
   location?: string;
   apiKey?: string;
+  /** True when the default backend is Vertex AI. Kept for backward compatibility. */
   useVertexAI: boolean;
+  /** Backend used when a request does not specify one. */
+  defaultBackend: Backend;
+  /** Backends that have credentials configured and can serve requests. */
+  availableBackends: Backend[];
   model: string;
   temperature: number;
   maxTokens: number;


### PR DESCRIPTION
> Stacked on #28 (base branch `feat/io-2026-model-update`). Review/merge #28 first; this PR's diff shows only the dual-backend changes. GitHub will retarget to `main` automatically once #28 merges.

## Motivation
Today the server binds to **one** backend at startup (`GOOGLE_GENAI_USE_VERTEXAI` / which credential is present). As a thin convenience layer, it should let callers use Vertex AI *and* Google AI Studio from a single deployment. This also resolves the PR #28 review note that the tool schema advertised Vertex-only fields even in AI Studio mode.

## What changed
- **config**: detect every backend that has credentials. `availableBackends` + `defaultBackend` are derived; the server now exits only when **no** backend is configured (previously it exited if the single selected backend's creds were missing). `useVertexAI` is retained (= default is Vertex) for backward compatibility.
- **service**: replace the single client with a lazy per-backend `GoogleGenAI` client map (`clientFor`). `query` / `generate_image` / `generate_speech` / `generate_video` / `generate_music` resolve the effective backend (`options.backend ?? defaultBackend`) and route to the matching client. Video long-running operations cache their **originating backend** so `check_video` polls on the same client.
- **schemas**: `buildVideoGenerationSchema` / `buildMusicGenerationSchema` take `availableBackends`. In dual mode the video `model` enum is the **union** of `-001` (Vertex) and `-preview` (AI Studio) IDs, and refinements are evaluated against the **per-request** backend:
  - Vertex-only: `seed`, `generateAudio`, `numberOfVideos>1`, `compressionQuality`, `resizeMode`
  - `personGeneration` mode rules, and music `audio/wav` (AI Studio + `lyria-3-pro-preview` only)
  - new `model`↔`backend` consistency check (a `-preview` model with `backend: vertex` is rejected)
  - `query` / `generate_image` / `generate_speech` accept an optional `backend`.
- **server**: the `backend` selector and union enums are advertised **only when multiple backends are configured**, so single-backend deployments keep a clean, accurate contract.

## Backward compatibility
Single-backend deployments are unchanged: no `backend` argument is advertised, and each backend keeps its own model enums / field gating. Verified via boot smoke tests for AI-Studio-only and Vertex-only modes.

## Verification
- `npm run build` (tsc) passes.
- **84/84** tests pass, including new coverage: dual-mode video & music schema gating, config backend detection (both creds; explicit `USE_VERTEXAI=false` override), and service per-request routing (default→override in both directions).
- Boot smoke test:
  - both creds → video enum = 6-model union, `backend`/`query.backend` = `[vertex, ai-studio]`, `numberOfVideos.max` = 4, music = `[mp3, wav]`
  - AI Studio only → `-preview` enum, no `backend`, max 1, `[mp3, wav]`
  - Vertex only → `-001` enum, no `backend`, max 4, `[mp3]`

## Follow-up (not in this PR)
- Docs: README env section + the new `backend` argument (recommended before merge to `main`).