### PR TITLE
feat: add Gemini Omni Flash video and Nano Banana 2 Lite image models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,7 @@ GEMINI_TOP_K=40
 # Defaults:
 # - Images: ~/Pictures/gemini-generated
 # - Videos: ~/Movies/gemini-generated on macOS, ~/Videos/gemini-generated on Windows/Linux
+#           (generate_video and generate_omni_video both save here)
 # - Speech: ~/Music/gemini-generated/speech
 # - Music: ~/Music/gemini-generated/music
 # GEMINI_IMAGE_OUTPUT_DIR=/path/to/images

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -386,7 +386,33 @@ async handle(
 
 **Configuration**: Uses `config.musicOutputDir` (defaults to `getDefaultMusicDir()` from audioSaver)
 
-### 13. Logger (File-based Logging)
+### 13. ReferenceSearchHandler (Grounded Reference Search)
+
+**Location**: `src/handlers/ReferenceSearchHandler.ts`
+
+**Responsibilities**:
+- Validate and route `reference_search` requests
+- Coordinate with GeminiAIService (`referenceSearch`) to compose an answer via Google Search grounding
+- Serialize the answer, citations, supports, search queries, and Search Suggestions markup into a JSON `text` block
+
+**Key Method**:
+```typescript
+async handle(
+  input: ReferenceSearchInput
+): Promise<{ content: Array<{ type: string; text: string }> }>
+```
+
+**Features**:
+- No file output — returns synthesized text plus organized citations (links) and claim→source supports in one call
+- Search-scope tuning is backend-asymmetric per the `@google/genai` GoogleSearch tool: `excludeDomains`/`blockingConfidence` are Vertex AI only, `timeRange` is Google AI Studio only; `includeImages` and `urls` (URL context) work on both
+- Grounding metadata is extracted from `response.candidates[0].groundingMetadata`; support segment byte offsets are sliced from the answer when the API omits resolved text
+
+**Response Format**:
+`reference_search` returns a text block containing JSON: `{ answer, citations, supports, searchQueries, searchSuggestionsHtml? }`.
+
+**Configuration**: No output directory — the answer is returned inline.
+
+### 14. Logger (File-based Logging)
 
 **Location**: `src/utils/Logger.ts`
 
@@ -400,7 +426,7 @@ async handle(
 - `logs/general.log`: All logs (info, error, tool calls)
 - `logs/reasoning.log`: Thinking traces only
 
-### 14. Generated File Utilities
+### 15. Generated File Utilities
 
 **Locations**: `src/utils/generatedFileSaver.ts`, `src/utils/imageSaver.ts`, `src/utils/videoSaver.ts`, `src/utils/audioSaver.ts`
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -404,7 +404,7 @@ async handle(
 
 **Features**:
 - No file output — returns synthesized text plus organized citations (links) and claim→source supports in one call
-- Search-scope tuning is backend-asymmetric per the `@google/genai` GoogleSearch tool: `excludeDomains`/`blockingConfidence` are Vertex AI only, `timeRange` is Google AI Studio only; `includeImages` and `urls` (URL context) work on both
+- Search-scope tuning is backend-asymmetric per the `@google/genai` GoogleSearch tool: `excludeDomains`/`blockingConfidence` are Vertex AI only, `timeRange` and `urls` (URL context) are Google AI Studio only; `includeImages` works on both
 - Grounding metadata is extracted from `response.candidates[0].groundingMetadata`; support segment byte offsets are sliced from the answer when the API omits resolved text
 
 **Response Format**:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -586,7 +586,7 @@ function pcmToWav(pcmData: Buffer, options?: WavOptions): Buffer
 2. OmniVideoGenerationSchema.parse(input) → validated OmniVideoGenerationInput
    ↓
 3. OmniVideoHandler.handle(input)
-   ├─ GeminiAIService.generateOmniVideo(prompt, { model, aspectRatio, durationSeconds, imagePaths, previousInteractionId, systemInstruction, backend })
+   ├─ GeminiAIService.generateOmniVideo(prompt, { model, aspectRatio, imagePaths, previousInteractionId, backend })
    │  ├─ Calls client.interactions.create() → returns the finished video synchronously
    │  ├─ Oneshot: text or text + inline reference images (imagePaths max 7)
    │  ├─ Interactive edit: previousInteractionId reuses the prior video (no re-upload)
@@ -749,19 +749,17 @@ Validates the `generate_omni_video` tool input. `gemini-omni-flash-preview` is a
 z.object({
   prompt: z.string(),
   model: z.enum(['gemini-omni-flash-preview']).optional(),
-  backend: z.enum(['vertex', 'ai-studio']).optional(),
+  backend: z.enum(['vertex', 'ai-studio']).optional(),     // defaults to ai-studio (Vertex not supported yet)
   aspectRatio: z.enum(['16:9', '9:16']).optional(),
-  durationSeconds: z.number().min(3).max(10).optional(),
   imagePaths: z.array(z.string()).max(7).optional(),      // image/reference-to-video
   previousInteractionId: z.string().optional(),           // interactive editing (chain up to 3)
-  systemInstruction: z.string().optional(),
 })
 ```
 
 **Notes**:
-- Output is 720p only; audio is auto-generated
+- Output is 720p only; audio is auto-generated. Clips run a few seconds — Omni Flash exposes no structured `duration` or `system_instruction` (both unsupported by the model), so steer timing/tone within `prompt`
 - Oneshot vs interactive editing: omit `previousInteractionId` for a new generation; set it to a prior call's `interactionId` to edit that video without re-uploading source media
-- Runs on the Google AI Studio (Gemini API) backend
+- Runs on the Google AI Studio (Gemini API) backend only, and defaults to it regardless of the server's default backend (Vertex AI availability is deferred until it rolls out)
 
 ### SpeechGenerationSchema
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 The Gemini AI MCP Server implements an **intelligent agentic loop** inspired by the OpenAI Agents SDK. The architecture supports turn-based execution, automatic tool selection, parallel tool execution, and robust error handling.
 
-**Last Updated**: 2026-04-28
+**Last Updated**: 2026-07-01
 
 ## Core Architecture
 
@@ -174,7 +174,8 @@ ARGUMENTS: {"url": "https://example.com", "extract": true}
 - Image generation via native image models
 - Speech generation via Gemini TTS models
 - Music generation via Lyria models
-- Video generation via Veo models
+- Video generation via Veo models (async long-running operations)
+- Omni video generation via Gemini Omni Flash through the Interactions API (synchronous)
 - Response text, image, and audio extraction
 
 **Key Methods**:
@@ -208,6 +209,11 @@ async generateVideo(
 async checkVideoOperation(
   operationId: string
 ): Promise<{ done: boolean; videos?: GeneratedVideo[]; error?: string }>
+
+async generateOmniVideo(
+  prompt: string,
+  options: OmniVideoGenerationOptions
+): Promise<GeneratedOmniVideo>  // Interactions API, synchronous (no operationId)
 ```
 
 **QueryOptions**:
@@ -326,7 +332,36 @@ async handleCheck(
 
 **Configuration**: Uses `config.videoOutputDir` (defaults to `getDefaultVideoDir()` from videoSaver)
 
-### 10. SpeechGenerationHandler (Speech Requests)
+### 10. OmniVideoHandler (Omni Video Requests)
+
+**Location**: `src/handlers/OmniVideoHandler.ts`
+
+**Responsibilities**:
+- Validate and route `generate_omni_video` requests (model `gemini-omni-flash-preview`)
+- Coordinate with GeminiAIService via the Interactions API (`client.interactions.create`)
+- Save the finished video to local filesystem via videoSaver
+- Surface the `interactionId` so callers can chain conversational edits
+
+**Key Method**:
+```typescript
+async handle(
+  input: OmniVideoGenerationInput
+): Promise<{ content: Array<{ type: string; text: string }> }>
+```
+
+**Features**:
+- Non-Veo video model; **synchronous** — returns the finished video in one call (no `operationId`/`check_video` polling), unlike the Veo `generate_video`/`check_video` long-running-operation pipeline
+- Oneshot path: text/image/reference-to-video (`imagePaths` max 7)
+- Interactive editing path: `previousInteractionId` chains up to 3 sequential edits without re-uploading source media
+- Constraints: 720p only, 16:9/9:16, duration 3-10s, audio auto-generated
+- Runs on the Google AI Studio (Gemini API) backend
+
+**Response Format**:
+`generate_omni_video` returns a text block containing JSON: `{ status: 'completed', interactionId, video: { filePath, mimeType }, text?, hint }`.
+
+**Configuration**: Uses `config.videoOutputDir` (defaults to `getDefaultVideoDir()` from videoSaver) — the same output directory as `generate_video`
+
+### 11. SpeechGenerationHandler (Speech Requests)
 
 **Location**: `src/handlers/SpeechGenerationHandler.ts`
 
@@ -339,7 +374,7 @@ async handleCheck(
 
 **Configuration**: Uses `config.speechOutputDir` (defaults to `getDefaultSpeechDir()` from audioSaver)
 
-### 11. MusicGenerationHandler (Music Requests)
+### 12. MusicGenerationHandler (Music Requests)
 
 **Location**: `src/handlers/MusicGenerationHandler.ts`
 
@@ -351,7 +386,7 @@ async handleCheck(
 
 **Configuration**: Uses `config.musicOutputDir` (defaults to `getDefaultMusicDir()` from audioSaver)
 
-### 12. Logger (File-based Logging)
+### 13. Logger (File-based Logging)
 
 **Location**: `src/utils/Logger.ts`
 
@@ -365,7 +400,7 @@ async handleCheck(
 - `logs/general.log`: All logs (info, error, tool calls)
 - `logs/reasoning.log`: Thinking traces only
 
-### 13. Generated File Utilities
+### 14. Generated File Utilities
 
 **Locations**: `src/utils/generatedFileSaver.ts`, `src/utils/imageSaver.ts`, `src/utils/videoSaver.ts`, `src/utils/audioSaver.ts`
 
@@ -517,6 +552,28 @@ function pcmToWav(pcmData: Buffer, options?: WavOptions): Buffer
    └─ text block: JSON { status: "completed", videos: [{ filePath, mimeType }] }
 ```
 
+### Omni Video Generation Flow
+
+```
+1. MCP Client → GeminiAIMCPServer (generate_omni_video tool call)
+   ↓
+2. OmniVideoGenerationSchema.parse(input) → validated OmniVideoGenerationInput
+   ↓
+3. OmniVideoHandler.handle(input)
+   ├─ GeminiAIService.generateOmniVideo(prompt, { model, aspectRatio, durationSeconds, imagePaths, previousInteractionId, systemInstruction, backend })
+   │  ├─ Calls client.interactions.create() → returns the finished video synchronously
+   │  ├─ Oneshot: text or text + inline reference images (imagePaths max 7)
+   │  ├─ Interactive edit: previousInteractionId reuses the prior video (no re-upload)
+   │  └─ Returns { interactionId, video: { data, mimeType }, text? }
+   │
+   ├─ generateVideoFilename(1) → "vid-{timestamp}-001.mp4"
+   ├─ saveVideo(data, videoOutputDir, filename) → saved file path
+   │
+   └─ text block: JSON { status: "completed", interactionId, video: { filePath, mimeType }, text?, hint }
+```
+
+Unlike the Veo pipeline, there is no `operationId` and no `check_video` follow-up call — the video is available immediately.
+
 ### Speech Generation Flow
 
 ```
@@ -608,15 +665,23 @@ Validates the `generate_image` tool input:
 ```typescript
 z.object({
   prompt: z.string(),
-  model: z.enum(['gemini-3-pro-image', 'gemini-3.1-flash-image', 'gemini-2.5-flash-image']).optional(),
+  model: z.enum(['gemini-3-pro-image', 'gemini-3.1-flash-image', 'gemini-3.1-flash-lite-image', 'gemini-2.5-flash-image']).optional(),
   aspectRatio: z.enum(['1:1','1:4','1:8','2:3','3:2','3:4','4:1','4:3','4:5','5:4','8:1','9:16','16:9','21:9']).optional(),
   imageSize: z.enum(['0.5K', '1K', '2K', '4K']).optional(),
   imagePaths: z.array(z.string()).max(14).optional(),
   systemInstruction: z.string().optional(),
-  thinkingLevel: z.enum(['minimal','low','medium','high']).optional(),
+  thinkingLevel: z.enum(['minimal','high']).optional(),
   mediaResolution: z.enum(['low','medium','high']).optional(),
 })
 ```
+
+**Validation Refines**:
+- `aspectRatio` 1:4, 1:8, 4:1, and 8:1 require `model: 'gemini-3.1-flash-image'`
+- `imageSize: '0.5K'` requires `model: 'gemini-3.1-flash-image'`
+- `imageSize` is not supported by `gemini-2.5-flash-image` (fixed 1K output)
+- `gemini-3.1-flash-lite-image` supports `imageSize: '1K'` only (standard ratios; no `thinkingLevel`)
+- `thinkingLevel` is only supported by `gemini-3.1-flash-image`
+- `gemini-2.5-flash-image` accepts at most 3 reference images (other models: 14)
 
 ### VideoGenerationSchema
 
@@ -650,14 +715,40 @@ z.object({
 - `videoPath` requires 720p and returns one extended video
 - Veo 3.1 Lite rejects `4k` and `referenceImagePaths`
 
-### SpeechGenerationSchema
+### OmniVideoGenerationSchema
 
-Validates the `generate_speech` tool input:
+Validates the `generate_omni_video` tool input. `gemini-omni-flash-preview` is a non-Veo video model driven through the Interactions API, so this schema is separate from `VideoGenerationSchema`:
 
 ```typescript
 z.object({
   prompt: z.string(),
-  model: z.enum(['gemini-3.1-flash-tts-preview', 'gemini-2.5-flash-preview-tts', 'gemini-2.5-pro-preview-tts']).optional(),
+  model: z.enum(['gemini-omni-flash-preview']).optional(),
+  backend: z.enum(['vertex', 'ai-studio']).optional(),
+  aspectRatio: z.enum(['16:9', '9:16']).optional(),
+  durationSeconds: z.number().min(3).max(10).optional(),
+  imagePaths: z.array(z.string()).max(7).optional(),      // image/reference-to-video
+  previousInteractionId: z.string().optional(),           // interactive editing (chain up to 3)
+  systemInstruction: z.string().optional(),
+})
+```
+
+**Notes**:
+- Output is 720p only; audio is auto-generated
+- Oneshot vs interactive editing: omit `previousInteractionId` for a new generation; set it to a prior call's `interactionId` to edit that video without re-uploading source media
+- Runs on the Google AI Studio (Gemini API) backend
+
+### SpeechGenerationSchema
+
+Validates the `generate_speech` tool input. The schema is backend-aware: `buildSpeechGenerationSchema(useVertexAI, availableBackends)` (mirroring `buildVideoGenerationSchema`) selects the model enum for the active backend. `SpeechGenerationSchema` is kept as the Vertex default export.
+
+```typescript
+z.object({
+  prompt: z.string(),
+  // Vertex AI GA ids: gemini-2.5-flash-tts, gemini-2.5-pro-tts
+  // Google AI Studio preview ids: gemini-2.5-flash-preview-tts, gemini-2.5-pro-preview-tts
+  // gemini-3.1-flash-tts-preview works on both backends
+  model: z.enum([/* backend-specific TTS ids */]).optional(),
+  backend: z.enum(['vertex', 'ai-studio']).optional(),
   voiceName: z.string().optional(),
   languageCode: z.string().optional(),
   speakers: z.array(z.object({
@@ -668,6 +759,7 @@ z.object({
 ```
 
 **Validation Refines**:
+- `model` must match the selected backend's TTS ids (Vertex AI: `gemini-2.5-flash-tts`/`gemini-2.5-pro-tts`; Google AI Studio: `gemini-2.5-flash-preview-tts`/`gemini-2.5-pro-preview-tts`; `gemini-3.1-flash-tts-preview` works on both)
 - `voiceName` cannot be used with `speakers`; set a voice per speaker instead
 
 ### MusicGenerationSchema
@@ -847,7 +939,7 @@ Each runs as separate process with independent:
 - `utils/` folder (Logger, generated file savers, security validators)
 - `handlers/` folder (QueryHandler, SearchHandler, FetchHandler, generation handlers)
 - Gemini 3 model support (`gemini-3.5-flash` default, `thinkingLevel` API)
-- File-output generation tools (`generate_image`, `generate_video`, `check_video`, `generate_speech`, `generate_music`)
+- File-output generation tools (`generate_image`, `generate_video`, `check_video`, `generate_omni_video`, `generate_speech`, `generate_music`)
 
 **Benefits**:
 - Keyword-based → LLM-driven decisions

--- a/GENERATION.md
+++ b/GENERATION.md
@@ -223,17 +223,15 @@ More examples: [examples/video-generation.md](examples/video-generation.md)
 | `prompt` | string | Required. Generation prompt (oneshot) or a natural-language edit instruction when `previousInteractionId` is set |
 | `model` | enum | `gemini-omni-flash-preview` |
 | `aspectRatio` | enum | `16:9`, `9:16` |
-| `durationSeconds` | number | Integer 3-10 |
 | `imagePaths` | string[] | Optional source/reference images for image-to-video or reference-to-video, max 7. Supported file types: PNG (`.png`), JPEG (`.jpg`, `.jpeg`), WEBP (`.webp`) |
 | `previousInteractionId` | string | `interactionId` from a prior call; conversationally edits that video with no image re-upload; chain up to 3 edits |
-| `systemInstruction` | string | Optional system instruction to steer generation or editing |
 
 Two paths:
 
 - Oneshot: text-to-video, or image/reference-to-video with `imagePaths`. Omit `previousInteractionId`.
 - Interactive editing: set `previousInteractionId` to an id returned by a prior call to edit that video with a natural-language instruction. No image re-upload; chain up to 3 sequential edits.
 
-Output is 720p only. A synced audio track is generated automatically; audio reference inputs are not accepted, so describe dialogue, sound effects, and ambience in `prompt` as text. The response text includes `interactionId` (pass it back as `previousInteractionId` to edit) and the saved file path.
+Output is 720p only and clips run a few seconds; Omni Flash has no structured duration parameter, so steer pacing/timing within `prompt`. A synced audio track is generated automatically; audio reference inputs are not accepted, so describe dialogue, sound effects, and ambience in `prompt` as text. The response text includes `interactionId` (pass it back as `previousInteractionId` to edit) and the saved file path.
 
 Oneshot:
 
@@ -242,8 +240,7 @@ Oneshot:
   "name": "generate_omni_video",
   "arguments": {
     "prompt": "A cinematic tracking shot through a quiet neon-lit robotics lab.",
-    "aspectRatio": "16:9",
-    "durationSeconds": 8
+    "aspectRatio": "16:9"
   }
 }
 ```

--- a/GENERATION.md
+++ b/GENERATION.md
@@ -19,6 +19,7 @@ On failures, generation tool calls return MCP error content instead of throwing 
 | `generate_music` | Lyria 3 models | MP3; WAV only for Gemini API/AI Studio Pro | `text` metadata + `audio` content |
 | `generate_video` | Veo 3.1 models | async operation ID | `text` metadata |
 | `check_video` | Veo operation polling | MP4 paths when complete | `text` metadata |
+| `generate_omni_video` | Gemini Omni Flash | MP4 path (synchronous) | `text` metadata |
 
 ## Default Output Directories
 
@@ -45,12 +46,12 @@ export GEMINI_MUSIC_OUTPUT_DIR="/path/to/music"
 | Parameter | Type | Notes |
 |-----------|------|-------|
 | `prompt` | string | Required |
-| `model` | enum | `gemini-3-pro-image`, `gemini-3.1-flash-image`, `gemini-2.5-flash-image` |
-| `aspectRatio` | enum | Includes standard ratios and 3.1 Flash-only wide/tall ratios |
-| `imageSize` | enum | `0.5K`, `1K`, `2K`, `4K`; omit for `gemini-2.5-flash-image` |
+| `model` | enum | `gemini-3-pro-image`, `gemini-3.1-flash-image`, `gemini-3.1-flash-lite-image`, `gemini-2.5-flash-image` |
+| `aspectRatio` | enum | Includes standard ratios and 3.1 Flash-only wide/tall ratios. `gemini-3.1-flash-lite-image` supports standard ratios only (not `1:4`/`1:8`/`4:1`/`8:1`) |
+| `imageSize` | enum | `0.5K`, `1K`, `2K`, `4K`; `gemini-3.1-flash-lite-image` supports `1K` only; omit for `gemini-2.5-flash-image` |
 | `imagePaths` | string[] | Optional local reference images, max 14; `gemini-2.5-flash-image` supports at most 3. Supported file types: PNG (`.png`), JPEG (`.jpg`, `.jpeg`), WEBP (`.webp`), HEIC (`.heic`), HEIF (`.heif`) |
 | `systemInstruction` | string | Optional Gemini 3 image system instruction |
-| `thinkingLevel` | enum | Optional Gemini 3.1 Flash Image thinking level: `minimal` or `high` |
+| `thinkingLevel` | enum | Optional Gemini 3.1 Flash Image thinking level: `minimal` or `high` (not supported by `gemini-3.1-flash-lite-image`) |
 | `mediaResolution` | enum | Optional media resolution for reference image inputs |
 
 Example:
@@ -67,6 +68,8 @@ Example:
 }
 ```
 
+`gemini-3.1-flash-lite-image` (Nano Banana 2 Lite) is the fast, low-cost GA tier: 1K output only, standard aspect ratios, no `thinkingLevel`, up to 14 reference images, and editing support. It is the recommended replacement for the legacy `gemini-2.5-flash-image` (still available, retires 2026-10-02).
+
 More examples: [examples/image-generation.md](examples/image-generation.md)
 
 ## generate_speech
@@ -78,7 +81,7 @@ Gemini TTS has a 32k-token context limit and does not support streaming in this 
 | Parameter | Type | Notes |
 |-----------|------|-------|
 | `prompt` | string | Required text or transcript |
-| `model` | enum | `gemini-3.1-flash-tts-preview`, `gemini-2.5-flash-preview-tts`, `gemini-2.5-pro-preview-tts` |
+| `model` | enum | `gemini-3.1-flash-tts-preview` (default, both backends). Backend-specific 2.5 tiers: Vertex AI GA `gemini-2.5-flash-tts`/`gemini-2.5-pro-tts`; Google AI Studio preview `gemini-2.5-flash-preview-tts`/`gemini-2.5-pro-preview-tts` |
 | `voiceName` | string | Single-speaker prebuilt voice, default `Kore` |
 | `languageCode` | string | Optional BCP-47 language code |
 | `speakers` | object[] | Exactly two `{ speaker, voiceName }` entries |
@@ -204,6 +207,54 @@ Poll:
   "name": "check_video",
   "arguments": {
     "operationId": "<operation-id-from-generate-video>"
+  }
+}
+```
+
+More examples: [examples/video-generation.md](examples/video-generation.md)
+
+## generate_omni_video
+
+`generate_omni_video` generates or conversationally edits short videos with Gemini Omni Flash (`gemini-omni-flash-preview`). This is a NON-Veo model on the Google AI Studio (Gemini API) backend and does not use `generate_video`/`check_video`: it returns the finished, saved video synchronously in one call, with no `operationId` and no `check_video` polling.
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `prompt` | string | Required. Generation prompt (oneshot) or a natural-language edit instruction when `previousInteractionId` is set |
+| `model` | enum | `gemini-omni-flash-preview` |
+| `aspectRatio` | enum | `16:9`, `9:16` |
+| `durationSeconds` | number | Integer 3-10 |
+| `imagePaths` | string[] | Optional source/reference images for image-to-video or reference-to-video, max 7. Supported file types: PNG (`.png`), JPEG (`.jpg`, `.jpeg`), WEBP (`.webp`) |
+| `previousInteractionId` | string | `interactionId` from a prior call; conversationally edits that video with no image re-upload; chain up to 3 edits |
+| `systemInstruction` | string | Optional system instruction to steer generation or editing |
+
+Two paths:
+
+- Oneshot: text-to-video, or image/reference-to-video with `imagePaths`. Omit `previousInteractionId`.
+- Interactive editing: set `previousInteractionId` to an id returned by a prior call to edit that video with a natural-language instruction. No image re-upload; chain up to 3 sequential edits.
+
+Output is 720p only. A synced audio track is generated automatically; audio reference inputs are not accepted, so describe dialogue, sound effects, and ambience in `prompt` as text. The response text includes `interactionId` (pass it back as `previousInteractionId` to edit) and the saved file path.
+
+Oneshot:
+
+```json
+{
+  "name": "generate_omni_video",
+  "arguments": {
+    "prompt": "A cinematic tracking shot through a quiet neon-lit robotics lab.",
+    "aspectRatio": "16:9",
+    "durationSeconds": 8
+  }
+}
+```
+
+Interactive edit:
+
+```json
+{
+  "name": "generate_omni_video",
+  "arguments": {
+    "prompt": "Add warm sunrise lighting and slow the camera down.",
+    "previousInteractionId": "<interaction-id-from-previous-call>"
   }
 }
 ```

--- a/GENERATION.md
+++ b/GENERATION.md
@@ -270,7 +270,8 @@ Search-scope tuning is backend-asymmetric per the `@google/genai` GoogleSearch t
 | `excludeDomains` (skip up to 2000 domains) | ✅ | ❌ |
 | `blockingConfidence` (block risky/low-quality sites) | ✅ | ❌ |
 | `timeRange` (restrict to a publish-time window) | ❌ | ✅ |
-| `includeImages`, `urls` (URL context) | ✅ | ✅ |
+| `urls` (URL context) | ❌ | ✅ |
+| `includeImages` | ✅ | ✅ |
 
 Return shape (JSON in the `text` block):
 

--- a/GENERATION.md
+++ b/GENERATION.md
@@ -20,6 +20,7 @@ On failures, generation tool calls return MCP error content instead of throwing 
 | `generate_video` | Veo 3.1 models | async operation ID | `text` metadata |
 | `check_video` | Veo operation polling | MP4 paths when complete | `text` metadata |
 | `generate_omni_video` | Gemini Omni Flash | MP4 path (synchronous) | `text` metadata |
+| `reference_search` | Gemini + Google Search grounding | synthesized answer + citations (no file) | `text` JSON |
 
 ## Default Output Directories
 
@@ -260,6 +261,53 @@ Interactive edit:
 ```
 
 More examples: [examples/video-generation.md](examples/video-generation.md)
+
+## reference_search
+
+`reference_search` answers a question from live web sources using Gemini's Google Search grounding, returning a synthesized answer plus organized citations in one call. It does not write a file — the result is a JSON `text` block. Unlike the OpenAI-spec `search`/`fetch` connector tools, it composes the answer AND returns the source links plus claim→source supports together.
+
+Search-scope tuning is backend-asymmetric per the `@google/genai` GoogleSearch tool, and invalid combinations are rejected at validation:
+
+| Tuning field | Vertex AI | Google AI Studio |
+|--------------|-----------|------------------|
+| `excludeDomains` (skip up to 2000 domains) | ✅ | ❌ |
+| `blockingConfidence` (block risky/low-quality sites) | ✅ | ❌ |
+| `timeRange` (restrict to a publish-time window) | ❌ | ✅ |
+| `includeImages`, `urls` (URL context) | ✅ | ✅ |
+
+Return shape (JSON in the `text` block):
+
+- `answer`: synthesized text grounded in the sources
+- `citations`: deduped `{ index, title, uri, domain }` sources
+- `supports`: answer segments mapped to citation indices with confidence scores
+- `searchQueries`: the queries the model actually ran
+- `searchSuggestionsHtml`: Google's required Search Suggestions markup (present when the API returns it) to display alongside the answer
+
+Recency-tuned research on Google AI Studio:
+
+```json
+{
+  "name": "reference_search",
+  "arguments": {
+    "prompt": "What changed in the latest Gemini API pricing?",
+    "backend": "ai-studio",
+    "timeRange": { "startTime": "2026-06-01T00:00:00Z", "endTime": "2026-07-01T00:00:00Z" }
+  }
+}
+```
+
+Curated web research on Vertex AI:
+
+```json
+{
+  "name": "reference_search",
+  "arguments": {
+    "prompt": "Production best practices for MCP servers",
+    "excludeDomains": ["reddit.com", "pinterest.com"],
+    "blockingConfidence": "medium"
+  }
+}
+```
 
 ## Authentication Mode Notes
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Generate file-based audio outputs:
 - Generation failures return structured MCP error content with `status`, `tool`, `errorType`, `message`, and validation `issues` when available
 - See [GENERATION.md](GENERATION.md), [AUDIO_GENERATION.md](AUDIO_GENERATION.md), [examples/audio-generation.md](examples/audio-generation.md), and [examples/video-generation.md](examples/video-generation.md)
 
+### 🔎 AI-Assisted Reference Search
+- **reference_search**: Answer a question from live web sources using Gemini's Google Search grounding, returning a synthesized answer plus organized citations (links) and claim→source supports in one call
+- Search-scope tuning is backend-specific: Vertex AI supports `excludeDomains` and `blockingConfidence`; Google AI Studio supports `timeRange`; both support `includeImages` and grounding on explicit `urls`
+
 ### 🔐 Security First
 
 **Multi-Layer Defense**:
@@ -287,7 +291,7 @@ See [PROMPT_CUSTOMIZATION.md](PROMPT_CUSTOMIZATION.md) for comprehensive guide a
 
 ## Available Tools
 
-The server exposes nine MCP tools: `query`, `search`, `fetch`, `generate_image`, `generate_speech`, `generate_music`, `generate_video`, `check_video`, and `generate_omni_video`.
+The server exposes ten MCP tools: `query`, `search`, `fetch`, `generate_image`, `generate_speech`, `generate_music`, `generate_video`, `check_video`, `generate_omni_video`, and `reference_search`.
 
 ### query
 
@@ -532,6 +536,43 @@ imagePaths: ["/path/to/frame.png"]
 # Interactive edit of a prior result
 generate_omni_video: "Make it night time and add rain"
 previousInteractionId: "<interactionId from previous call>"
+```
+
+### reference_search
+
+AI-assisted reference search: answer a question from live web sources using Gemini's Google Search grounding, and return organized citations. Unlike the OpenAI-spec `search`/`fetch` connector tools, this composes a synthesized answer **and** returns the source links plus claim→source supports in one call.
+
+**Parameters:**
+- `prompt` (string, required): Research question or topic to answer from live web sources
+- `model` (string, optional): Gemini model override; must support Google Search grounding (default: server model)
+- `excludeDomains` (array, optional): Domains to exclude from results, e.g. `["reddit.com","pinterest.com"]` (max 2000). **Vertex AI backend only**
+- `blockingConfidence` (string, optional): Block risky/low-quality sites at or above this confidence. Options: `low` (most aggressive), `medium`, `high`. **Vertex AI backend only**
+- `timeRange` (object, optional): Restrict results to a publish-time window (`startTime`/`endTime`, both required RFC 3339). **Google AI Studio backend only**
+- `includeImages` (boolean, optional): Also enable image-search grounding in addition to web search
+- `urls` (array, optional): Specific http(s) URLs to ground the answer on via URL context (max 20; both backends)
+- `systemInstruction` (string, optional): System instruction to steer the tone, depth, or scope of the answer
+- `thinkingLevel` (string, optional): Gemini 3 thinking level override. Options: `minimal`, `low`, `medium`, `high`
+
+**Behavior:**
+- Returns a JSON payload: `answer` (synthesized text), `citations` (deduped `{index,title,uri,domain}` sources), `supports` (answer segments mapped to citation indices with confidence scores), `searchQueries` (the queries the model actually ran), and `searchSuggestionsHtml` (Google's required Search Suggestions markup to display alongside the answer)
+- Search-scope tuning is backend-asymmetric — invalid combinations are rejected at validation with a structured error naming the supported backend
+- When `urls` are supplied, a URL context tool is added so the model also grounds on those specific pages
+
+**Examples:**
+```
+# Recency-tuned research on Google AI Studio
+reference_search: "What changed in the latest Gemini API pricing?"
+backend: "ai-studio"
+timeRange: { "startTime": "2026-06-01T00:00:00Z", "endTime": "2026-07-01T00:00:00Z" }
+
+# Curated web research on Vertex AI (skip low-signal domains)
+reference_search: "Production best practices for MCP servers"
+excludeDomains: ["reddit.com", "pinterest.com"]
+blockingConfidence: "medium"
+
+# Ground on specific pages
+reference_search: "Summarize the key points from these docs"
+urls: ["https://ai.google.dev/gemini-api/docs/grounding"]
 ```
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -510,11 +510,9 @@ Generate or conversationally edit short videos with Gemini Omni Flash (`gemini-o
 **Parameters:**
 - `prompt` (string, required): Video prompt for a new generation (oneshot), or a natural-language edit instruction when `previousInteractionId` is set
 - `model` (string, optional): Omni video model. Options: `gemini-omni-flash-preview` (default)
-- `aspectRatio` (string, optional): Aspect ratio. Default: `16:9`. Options: `16:9`, `9:16`
-- `durationSeconds` (number, optional): Video duration in seconds. Options: `3`–`10`. Output is 720p only
+- `aspectRatio` (string, optional): Aspect ratio. Default: `16:9`. Options: `16:9`, `9:16`. Output is 720p only; clips run a few seconds — steer timing within the `prompt` (Omni Flash has no structured duration parameter)
 - `imagePaths` (array, optional): Local file paths of source/reference images for image-to-video or reference-to-video (max 7). Supported file types: PNG (`.png`), JPEG (`.jpg`, `.jpeg`), WEBP (`.webp`). Omit for interactive edits
 - `previousInteractionId` (string, optional): Interaction ID from a prior `generate_omni_video` call. When set, conversationally edits that video (no image re-upload) instead of generating a new one
-- `systemInstruction` (string, optional): System instruction to steer generation or editing
 
 **Behavior:**
 - Two paths: (1) **oneshot** generation — text-to-video, or image/reference-to-video via `imagePaths`; (2) **interactive** editing — set `previousInteractionId` to edit a prior video with a natural-language instruction (no image re-upload; chain up to 3 sequential edits)
@@ -527,7 +525,6 @@ Generate or conversationally edit short videos with Gemini Omni Flash (`gemini-o
 # Oneshot text-to-video
 generate_omni_video: "A golden retriever surfing a wave at sunset"
 aspectRatio: "16:9"
-durationSeconds: 8
 
 # Image-to-video
 generate_omni_video: "Animate this scene with gentle camera motion"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Generate file-based audio outputs:
 
 ### 🔎 AI-Assisted Reference Search
 - **reference_search**: Answer a question from live web sources using Gemini's Google Search grounding, returning a synthesized answer plus organized citations (links) and claim→source supports in one call
-- Search-scope tuning is backend-specific: Vertex AI supports `excludeDomains` and `blockingConfidence`; Google AI Studio supports `timeRange`; both support `includeImages` and grounding on explicit `urls`
+- Search-scope tuning is backend-specific: Vertex AI supports `excludeDomains` and `blockingConfidence`; Google AI Studio supports `timeRange` and grounding on explicit `urls` (URL context); both support `includeImages`
 
 ### 🔐 Security First
 
@@ -546,7 +546,7 @@ AI-assisted reference search: answer a question from live web sources using Gemi
 - `blockingConfidence` (string, optional): Block risky/low-quality sites at or above this confidence. Options: `low` (most aggressive), `medium`, `high`. **Vertex AI backend only**
 - `timeRange` (object, optional): Restrict results to a publish-time window (`startTime`/`endTime`, both required RFC 3339). **Google AI Studio backend only**
 - `includeImages` (boolean, optional): Also enable image-search grounding in addition to web search
-- `urls` (array, optional): Specific http(s) URLs to ground the answer on via URL context (max 20; both backends)
+- `urls` (array, optional): Specific http(s) URLs to ground the answer on via URL context (max 20). **Google AI Studio backend only** — the URL context tool is not available on Vertex AI
 - `systemInstruction` (string, optional): System instruction to steer the tone, depth, or scope of the answer
 - `thinkingLevel` (string, optional): Gemini 3 thinking level override. Options: `minimal`, `low`, `medium`, `high`
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This server provides:
 - **Agentic Loop**: Turn-based execution with automatic tool selection and reasoning
 - **Query Gemini**: Access Gemini models via Vertex AI or Google AI Studio
 - **Multimodal Support**: Send images, audio, video, and code files alongside text prompts
-- **Image Generation**: Generate images using Gemini image models (gemini-3-pro-image, gemini-3.1-flash-image, gemini-2.5-flash-image)
+- **Image Generation**: Generate images using Gemini image models (gemini-3-pro-image, gemini-3.1-flash-image, gemini-3.1-flash-lite-image, gemini-2.5-flash-image)
 - **Speech & Music Generation**: Generate TTS audio with Gemini TTS and music with Lyria
 - **Tool Execution**: Built-in WebFetch + integration with external MCP servers
 - **Multi-turn Conversations**: Maintain context across queries with session management
@@ -58,7 +58,8 @@ Full support for Gemini 3 generation models:
 Generate images directly from text prompts using Gemini image models:
 - **gemini-3-pro-image**: Professional asset production with 4K resolution support (default)
 - **gemini-3.1-flash-image**: High-efficiency generation with 0.5K-4K resolution and reference images
-- **gemini-2.5-flash-image**: Fast 1K image generation and editing (retiring 2026-10-02; prefer gemini-3.1-flash-image)
+- **gemini-3.1-flash-lite-image** (Nano Banana 2 Lite): Fast, low-cost GA tier — 1K output only, standard aspect ratios, up to 14 reference images, image editing (recommended replacement for gemini-2.5-flash-image)
+- **gemini-2.5-flash-image**: Fast 1K image generation and editing (legacy, retiring 2026-10-02; prefer gemini-3.1-flash-lite-image)
 - Configurable aspect ratios: 1:1, 16:9, 9:16, 4:3, and more
 - Images automatically saved to configurable output directory
 
@@ -286,7 +287,7 @@ See [PROMPT_CUSTOMIZATION.md](PROMPT_CUSTOMIZATION.md) for comprehensive guide a
 
 ## Available Tools
 
-The server exposes eight MCP tools: `query`, `search`, `fetch`, `generate_image`, `generate_speech`, `generate_music`, `generate_video`, and `check_video`.
+The server exposes nine MCP tools: `query`, `search`, `fetch`, `generate_image`, `generate_speech`, `generate_music`, `generate_video`, `check_video`, and `generate_omni_video`.
 
 ### query
 
@@ -371,9 +372,10 @@ Generate images from text prompts using Gemini image models.
 - `model` (string, optional): Image model to use. Options:
   - `gemini-3-pro-image` (default) — professional quality, supports up to 4K resolution
   - `gemini-3.1-flash-image` — high-efficiency with 0.5K-4K and reference image support
-  - `gemini-2.5-flash-image` — fast 1K image generation and editing (retiring 2026-10-02; prefer gemini-3.1-flash-image)
+  - `gemini-3.1-flash-lite-image` (Nano Banana 2 Lite) — fast, low-cost GA tier; 1K output only, standard aspect ratios (no `1:4`/`1:8`/`4:1`/`8:1`), no `thinkingLevel`, up to 14 reference images and image editing (recommended replacement for gemini-2.5-flash-image)
+  - `gemini-2.5-flash-image` — fast 1K image generation and editing (legacy, retiring 2026-10-02; prefer gemini-3.1-flash-lite-image)
 - `aspectRatio` (string, optional): Image aspect ratio. Default: `1:1`. Options: `1:1`, `1:4`, `1:8`, `2:3`, `3:2`, `3:4`, `4:1`, `4:3`, `4:5`, `5:4`, `8:1`, `9:16`, `16:9`, `21:9` (`1:4`, `1:8`, `4:1`, `8:1` require `gemini-3.1-flash-image`)
-- `imageSize` (string, optional): Output resolution. Default: `1K`. Options: `0.5K`, `1K`, `2K`, `4K` (`0.5K` requires `gemini-3.1-flash-image`; omit for `gemini-2.5-flash-image`)
+- `imageSize` (string, optional): Output resolution. Default: `1K`. Options: `0.5K`, `1K`, `2K`, `4K` (`0.5K` requires `gemini-3.1-flash-image`; `gemini-3.1-flash-lite-image` supports `1K` only; omit for `gemini-2.5-flash-image`)
 - `imagePaths` (array, optional): Local reference images for editing or style transfer (max 14; `gemini-2.5-flash-image` supports at most 3). Supported file types: PNG (`.png`), JPEG (`.jpg`, `.jpeg`), WEBP (`.webp`), HEIC (`.heic`), HEIF (`.heif`)
 - `systemInstruction` (string, optional): System instruction for Gemini 3 image models
 - `thinkingLevel` (string, optional): Gemini 3.1 Flash Image thinking level: `minimal` or `high`
@@ -401,7 +403,7 @@ Generate speech from text using Gemini TTS models.
 
 **Parameters:**
 - `prompt` (string, required): Text or transcript to synthesize
-- `model` (string, optional): Speech model. Options: `gemini-3.1-flash-tts-preview` (default), `gemini-2.5-flash-preview-tts`, `gemini-2.5-pro-preview-tts`
+- `model` (string, optional): Speech model. `gemini-3.1-flash-tts-preview` (default) works on both backends. The 2.5 tiers differ per backend: Vertex AI uses `gemini-2.5-flash-tts` / `gemini-2.5-pro-tts`; Google AI Studio uses `gemini-2.5-flash-preview-tts` / `gemini-2.5-pro-preview-tts`
 - `voiceName` (string, optional): Prebuilt voice for single-speaker TTS. Default: `Kore`
 - `languageCode` (string, optional): BCP-47 language code
 - `speakers` (array, optional): Exactly two `{ speaker, voiceName }` entries for multi-speaker TTS
@@ -495,6 +497,41 @@ referenceImagePaths: ["/path/to/style1.jpg", "/path/to/style2.jpg"]
 generate_video: "Follow the subject as the scene continues into the hallway"
 videoPath: "/path/to/previous-veo-output.mp4"
 resolution: "720p"
+```
+
+### generate_omni_video
+
+Generate or conversationally edit short videos with Gemini Omni Flash (`gemini-omni-flash-preview`). This is a **non-Veo** video model on the Google AI Studio (Gemini API) backend, using the Interactions API. Unlike `generate_video`/`check_video`, it is **synchronous** — a single call returns the finished, saved video (no operation ID, no polling).
+
+**Parameters:**
+- `prompt` (string, required): Video prompt for a new generation (oneshot), or a natural-language edit instruction when `previousInteractionId` is set
+- `model` (string, optional): Omni video model. Options: `gemini-omni-flash-preview` (default)
+- `aspectRatio` (string, optional): Aspect ratio. Default: `16:9`. Options: `16:9`, `9:16`
+- `durationSeconds` (number, optional): Video duration in seconds. Options: `3`–`10`. Output is 720p only
+- `imagePaths` (array, optional): Local file paths of source/reference images for image-to-video or reference-to-video (max 7). Supported file types: PNG (`.png`), JPEG (`.jpg`, `.jpeg`), WEBP (`.webp`). Omit for interactive edits
+- `previousInteractionId` (string, optional): Interaction ID from a prior `generate_omni_video` call. When set, conversationally edits that video (no image re-upload) instead of generating a new one
+- `systemInstruction` (string, optional): System instruction to steer generation or editing
+
+**Behavior:**
+- Two paths: (1) **oneshot** generation — text-to-video, or image/reference-to-video via `imagePaths`; (2) **interactive** editing — set `previousInteractionId` to edit a prior video with a natural-language instruction (no image re-upload; chain up to 3 sequential edits)
+- 720p output only; a synced audio track is generated automatically (audio reference inputs are not accepted — describe dialogue, sound effects, and ambience in `prompt`)
+- Generated videos are saved to `GEMINI_VIDEO_OUTPUT_DIR` (defaults to `~/Movies/gemini-generated` on macOS, `~/Videos/gemini-generated` on Windows/Linux)
+- The response includes `interactionId` (pass it back as `previousInteractionId` to edit) and the saved video file path
+
+**Examples:**
+```
+# Oneshot text-to-video
+generate_omni_video: "A golden retriever surfing a wave at sunset"
+aspectRatio: "16:9"
+durationSeconds: 8
+
+# Image-to-video
+generate_omni_video: "Animate this scene with gentle camera motion"
+imagePaths: ["/path/to/frame.png"]
+
+# Interactive edit of a prior result
+generate_omni_video: "Make it night time and add rain"
+previousInteractionId: "<interactionId from previous call>"
 ```
 
 ## Security

--- a/docs/adr/2026-07-01-nano-banana-2-lite-omni-flash-sdk.md
+++ b/docs/adr/2026-07-01-nano-banana-2-lite-omni-flash-sdk.md
@@ -1,0 +1,145 @@
+# ADR: Nano Banana 2 Lite Image, Gemini Omni Flash Video, Backend-Aware TTS, and SDK Bump
+
+## Status
+
+Accepted — 2026-07-01
+
+## Context
+
+Google's mid-2026 model releases add capabilities that do not fit cleanly into the existing generation tools:
+
+1. **Nano Banana 2 Lite** (`gemini-3.1-flash-lite-image`) went GA as a lower-cost image tier. It is more constrained than the other Nano Banana image models: 1K output only, standard aspect ratios only, no `thinkingLevel`, and up to 14 reference images.
+2. **Gemini Omni Flash** (`gemini-omni-flash-preview`) is a new video model that is **not** part of the Veo family. It is invoked through the `@google/genai` Interactions API (`client.interactions.create`) rather than the Veo `generateVideos` long-running-operation pipeline, and it supports stateful conversational editing.
+3. The legacy `gemini-2.5-flash-image` model is scheduled to retire on 2026-10-02, so it must remain available with a documented retirement date rather than being removed immediately.
+4. The TTS model ids diverged by backend: Vertex AI exposes GA `-tts` ids while Google AI Studio exposes `-preview-tts` preview ids. A single static speech model enum can false-reject valid requests for one backend.
+
+These changes require a newer `@google/genai` and `@modelcontextprotocol/sdk`, and they must be reconciled against the existing generation tool set without regressing the Veo pipeline, the backend-aware video/music schemas ([2026-04-28 backend capability detection](2026-04-28-backend-capability-detection.md)), or the speech/music tools ([2026-04-28 speech and music generation](2026-04-28-speech-and-music-generation.md)).
+
+## Decision
+
+### SDK bump
+
+Bump `@google/genai` from `^2.8.0` to `^2.10.0` and `@modelcontextprotocol/sdk` from `^1.26.0` to `^1.29.0`.
+
+The only breaking change in the `@google/genai` 2.x line was 2.0.0, and it was scoped to the Interactions API surface. The generation calls this server relies on — `models.generateContent` (query, image, speech, music), `models.generateVideos` / `operations.getVideosOperation` (Veo), and now `interactions.create` (Omni Flash) — are unchanged from 2.8.0 through 2.10.0. The MCP SDK 1.26 → 1.29 range is additive for the tool/list and call handlers this server implements. The bump is therefore non-breaking for this repo.
+
+### Nano Banana 2 Lite image model
+
+Add `gemini-3.1-flash-lite-image` to `ALLOWED_IMAGE_MODELS` and keep `gemini-2.5-flash-image` (legacy, retires 2026-10-02). The new model order is:
+
+1. `gemini-3-pro-image` (default)
+2. `gemini-3.1-flash-image`
+3. `gemini-3.1-flash-lite-image`
+4. `gemini-2.5-flash-image`
+
+Capability refines for `gemini-3.1-flash-lite-image`:
+
+- Gate `imageSize` to `1K` only (reject `0.5K`/`2K`/`4K`; omit for its default 1K output).
+- It is not eligible for the flash-image-only asymmetric aspect ratios (`1:4`, `1:8`, `4:1`, `8:1`), which remain restricted to `gemini-3.1-flash-image`.
+- It is not eligible for `thinkingLevel`, which remains restricted to `gemini-3.1-flash-image`.
+- Reference-image cap stays at 14 (only `gemini-2.5-flash-image` is limited to 3).
+
+### Gemini Omni Flash as a separate tool
+
+Add a new `generate_omni_video` tool (model `gemini-omni-flash-preview`) with its own `OmniVideoGenerationSchema`, `GeminiAIService.generateOmniVideo()`, and `OmniVideoHandler`, wired into `GeminiAIMCPServer`.
+
+- **Interactions API, synchronous**: `client.interactions.create` returns the finished video in a single call. There is no `operationId` and no `check_video` follow-up.
+- **Dual path**:
+  - *Oneshot*: text-to-video, image-to-video, or reference-to-video (`imagePaths` max 7).
+  - *Interactive editing*: `previousInteractionId` chains up to 3 sequential edits, reusing the prior video without re-uploading source media.
+- **Constraints**: 720p only, `16:9`/`9:16`, duration 3-10s, audio auto-generated.
+- **Backend**: Google AI Studio (Gemini API).
+- **Output**: saved to the same video output directory as `generate_video` (`config.videoOutputDir` / `getDefaultVideoDir()`), via the existing `videoSaver`.
+
+### Backend-aware TTS split
+
+Split the single speech model enum into per-backend lists and introduce `buildSpeechGenerationSchema(useVertexAI, availableBackends)`, mirroring `buildVideoGenerationSchema` / `buildMusicGenerationSchema`:
+
+- Vertex AI GA: `gemini-2.5-flash-tts`, `gemini-2.5-pro-tts`
+- Google AI Studio preview: `gemini-2.5-flash-preview-tts`, `gemini-2.5-pro-preview-tts`
+- Both backends: `gemini-3.1-flash-tts-preview` (default)
+
+A refine rejects a model that does not match the selected (or default) backend. `SpeechGenerationSchema` is kept as the Vertex default export.
+
+### Availability audit (non-decisions)
+
+The text, Lyria music, and Veo video model id lists were audited against official documentation as of 2026-07 and are all current. No id changes were made to those tools in this ADR.
+
+## Rationale
+
+### Why Omni Flash could not fold into `generate_video`
+
+The Veo `generate_video` schema and pipeline are structurally incompatible with Omni Flash:
+
+- **Different SDK surface**: Veo uses `models.generateVideos` returning a long-running operation polled with `operations.getVideosOperation`; the tool contract exposes this as `generate_video` → `{ operationId }` → `check_video`. Omni Flash uses `interactions.create` and returns the video synchronously. Folding it in would force one of the two models into the wrong async contract.
+- **Different parameter surface**: `VideoGenerationSchema` carries Veo-specific fields (`seed`, `numberOfVideos`, `enhancePrompt`, `personGeneration`, `compressionQuality`, `resizeMode`, `lastFramePath`, `videoPath`, `referenceImagePaths` max 3, resolutions up to `4k`, backend-specific `-001`/`-preview` id enums). Omni Flash accepts none of these; it adds `previousInteractionId` and a different `imagePaths` cap (7) and constraint set (720p only, duration 3-10s as a number). Overloading one schema would require mutually exclusive branches gated on the model, degrading validation clarity.
+- **Different state model**: Omni Flash's `previousInteractionId` editing has no Veo analogue. Expressing a stateful edit chain inside a stateless one-shot Veo schema would be misleading.
+
+A separate tool keeps each schema deterministic and each pipeline honest about its async/state behavior, consistent with the existing "separate tools for distinct model families" principle used for speech vs music.
+
+### Why the lite refines are 1K-only and keep 2.5-flash-image
+
+`gemini-3.1-flash-lite-image` documents 1K-only, standard-ratio output with no thinking, so schema refines reject the higher/lower `imageSize` values and the asymmetric ratios instead of silently forwarding requests the model will reject. `gemini-2.5-flash-image` is kept because it is still GA until 2026-10-02; removing it now would break callers pinned to it before its retirement.
+
+### Why the per-backend TTS split
+
+The prior single enum mixed Vertex GA and AI Studio preview ids, so it could accept an id the active backend rejects. Keying the model enum and a match refine to the resolved backend makes speech validation deterministic per backend, matching the pattern already used for Veo video and Lyria music.
+
+## Consequences
+
+### Positive
+
+- Callers can select the cheaper Nano Banana 2 Lite image tier with schema-level guardrails for its constraints.
+- `generate_omni_video` exposes synchronous, editable video generation without disturbing the Veo `generate_video`/`check_video` contract.
+- Omni videos land in the same output directory as Veo videos, so downstream file handling is unchanged.
+- Speech validation no longer false-rejects backend-appropriate 2.5 TTS ids.
+- The SDK bump picks up upstream fixes with no code changes required for this repo's call patterns.
+
+### Tradeoffs
+
+- The image, video, and speech capability tables grow and still require maintenance when Google changes model ids or limits.
+- `gemini-2.5-flash-image` remains in the enum until its 2026-10-02 retirement and will need a follow-up removal.
+- Omni Flash is preview and Google AI Studio-only for now; Vertex AI availability is deferred until it rolls out.
+- A second, structurally different video tool increases the tool surface clients must understand (synchronous vs long-running).
+
+## Implementation Notes
+
+- `package.json`
+  - `@google/genai` `^2.8.0` → `^2.10.0`.
+  - `@modelcontextprotocol/sdk` `^1.26.0` → `^1.29.0`.
+
+- `src/schemas/index.ts`
+  - Added `gemini-3.1-flash-lite-image` to `ALLOWED_IMAGE_MODELS` (new order: 3-pro-image, 3.1-flash-image, 3.1-flash-lite-image, 2.5-flash-image).
+  - Added an image refine gating `gemini-3.1-flash-lite-image` to `imageSize: '1K'` only.
+  - Added `ALLOWED_OMNI_VIDEO_MODELS`, `OMNI_VIDEO_INPUT_FILE_TYPES`, `OmniVideoGenerationSchema`, and `OmniVideoGenerationInput`.
+  - Split speech models into `ALLOWED_VERTEX_SPEECH_MODELS` / `ALLOWED_GEMINI_API_SPEECH_MODELS`, added `getAllowedSpeechModels(useVertexAI)` and `buildSpeechGenerationSchema(useVertexAI, availableBackends)` with a backend-match refine; kept `SpeechGenerationSchema` as the Vertex default.
+
+- `src/services/GeminiAIService.ts`
+  - Added `generateOmniVideo(prompt, options)` using `client.interactions.create` with `store: true`, optional `previous_interaction_id`, and inline reference images for image/reference-to-video.
+
+- `src/handlers/OmniVideoHandler.ts`
+  - New handler; saves the synchronous video via `videoSaver` to `config.videoOutputDir` and returns `{ status, interactionId, video, text?, hint }`.
+
+- `src/server/GeminiAIMCPServer.ts`
+  - Registered `generate_omni_video` in `tools/list` and its call handler.
+  - Parses `generate_speech` calls with `buildSpeechGenerationSchema(this.config.useVertexAI, this.config.availableBackends)`.
+
+- Documentation
+  - `ARCHITECTURE.md`: added the `OmniVideoHandler` component, `OmniVideoGenerationSchema` section, Omni video generation flow, backend-aware speech schema notes, and the lite image model/refines.
+  - `.env.example`: noted that `generate_omni_video` shares the video output directory.
+
+## Availability Audit
+
+Audited against official documentation as of 2026-07. No id changes were required for:
+
+- **Text** query models (`gemini-3.5-flash` default and the 3.1 pro/flash-lite variants).
+- **Lyria music** models (`lyria-3-clip-preview`, `lyria-3-pro-preview`).
+- **Veo video** models (Vertex `-001` GA ids and Gemini Developer API `-preview` ids).
+
+## References
+
+- Gemini image generation (Nano Banana models, sizes, ratios, thinking levels): https://ai.google.dev/gemini-api/docs/image-generation
+- Gemini API video generation (Veo model versions and output limits): https://ai.google.dev/gemini-api/docs/video
+- Gemini API speech generation (TTS models): https://ai.google.dev/gemini-api/docs/speech-generation
+- Gemini API music generation (Lyria 3): https://ai.google.dev/gemini-api/docs/music-generation
+- `@google/genai` release docs: https://googleapis.github.io/js-genai/release_docs/index.html

--- a/docs/adr/2026-07-01-nano-banana-2-lite-omni-flash-sdk.md
+++ b/docs/adr/2026-07-01-nano-banana-2-lite-omni-flash-sdk.md
@@ -47,8 +47,8 @@ Add a new `generate_omni_video` tool (model `gemini-omni-flash-preview`) with it
 - **Dual path**:
   - *Oneshot*: text-to-video, image-to-video, or reference-to-video (`imagePaths` max 7).
   - *Interactive editing*: `previousInteractionId` chains up to 3 sequential edits, reusing the prior video without re-uploading source media.
-- **Constraints**: 720p only, `16:9`/`9:16`, duration 3-10s, audio auto-generated.
-- **Backend**: Google AI Studio (Gemini API).
+- **Constraints**: 720p only, `16:9`/`9:16`, short clips (a few seconds), audio auto-generated. Per the Omni Flash docs, `duration` is **not** a structured `response_format` field and `system_instruction` is **not supported** — neither is exposed as a tool parameter; timing/tone are steered within the prompt.
+- **Backend**: Google AI Studio (Gemini API) only. `generateOmniVideo` defaults the backend to `ai-studio` (not the server default backend) so a Vertex-default setup still reaches Omni; an explicit `backend` override is honored for when Vertex availability rolls out.
 - **Output**: saved to the same video output directory as `generate_video` (`config.videoOutputDir` / `getDefaultVideoDir()`), via the existing `videoSaver`.
 
 ### Backend-aware TTS split
@@ -72,7 +72,7 @@ The text, Lyria music, and Veo video model id lists were audited against officia
 The Veo `generate_video` schema and pipeline are structurally incompatible with Omni Flash:
 
 - **Different SDK surface**: Veo uses `models.generateVideos` returning a long-running operation polled with `operations.getVideosOperation`; the tool contract exposes this as `generate_video` → `{ operationId }` → `check_video`. Omni Flash uses `interactions.create` and returns the video synchronously. Folding it in would force one of the two models into the wrong async contract.
-- **Different parameter surface**: `VideoGenerationSchema` carries Veo-specific fields (`seed`, `numberOfVideos`, `enhancePrompt`, `personGeneration`, `compressionQuality`, `resizeMode`, `lastFramePath`, `videoPath`, `referenceImagePaths` max 3, resolutions up to `4k`, backend-specific `-001`/`-preview` id enums). Omni Flash accepts none of these; it adds `previousInteractionId` and a different `imagePaths` cap (7) and constraint set (720p only, duration 3-10s as a number). Overloading one schema would require mutually exclusive branches gated on the model, degrading validation clarity.
+- **Different parameter surface**: `VideoGenerationSchema` carries Veo-specific fields (`seed`, `numberOfVideos`, `enhancePrompt`, `personGeneration`, `compressionQuality`, `resizeMode`, `lastFramePath`, `videoPath`, `referenceImagePaths` max 3, resolutions up to `4k`, backend-specific `-001`/`-preview` id enums). Omni Flash accepts none of these; it adds `previousInteractionId` and a different `imagePaths` cap (7) and constraint set (720p only, short clips with no structured duration parameter). Overloading one schema would require mutually exclusive branches gated on the model, degrading validation clarity.
 - **Different state model**: Omni Flash's `previousInteractionId` editing has no Veo analogue. Expressing a stateful edit chain inside a stateless one-shot Veo schema would be misleading.
 
 A separate tool keeps each schema deterministic and each pipeline honest about its async/state behavior, consistent with the existing "separate tools for distinct model families" principle used for speech vs music.

--- a/examples/image-generation.md
+++ b/examples/image-generation.md
@@ -40,13 +40,14 @@ The response contains:
 
 ## Model Selection
 
-Three image generation models are available:
+Four image generation models are available:
 
 | Model | Description |
 |-------|-------------|
 | `gemini-3-pro-image` | Default. Professional asset production, supports up to 4K resolution |
 | `gemini-3.1-flash-image` | High-efficiency with 0.5K-4K, reference images, and new aspect ratios |
-| `gemini-2.5-flash-image` | Fast 1K image generation and editing (retiring 2026-10-02; prefer gemini-3.1-flash-image) |
+| `gemini-3.1-flash-lite-image` | Nano Banana 2 Lite. Fast, low-cost GA tier: 1K only, standard aspect ratios, no thinking, up to 14 reference images, editing |
+| `gemini-2.5-flash-image` | Fast 1K image generation and editing (retiring 2026-10-02; prefer gemini-3.1-flash-lite-image) |
 
 ```typescript
 const request = {
@@ -54,6 +55,19 @@ const request = {
   arguments: {
     prompt: "A photorealistic portrait of a red fox in a forest",
     model: "gemini-3.1-flash-image"
+  }
+};
+```
+
+For fast, low-cost 1K images, use `gemini-3.1-flash-lite-image`. It outputs 1K only, so omit `imageSize` (or set it to `1K`), and it accepts standard aspect ratios only.
+
+```typescript
+const request = {
+  name: "generate_image",
+  arguments: {
+    prompt: "A friendly cartoon mascot waving, flat vector style",
+    model: "gemini-3.1-flash-lite-image",
+    aspectRatio: "1:1"
   }
 };
 ```
@@ -110,7 +124,7 @@ The `imageSize` parameter sets the output resolution. Defaults to `1K`.
 | Value | Resolution | Supported Models |
 |-------|------------|-----------------|
 | `0.5K` | ~512px | `gemini-3.1-flash-image` |
-| `1K` | ~1024px (default) | `gemini-3-pro-image`, `gemini-3.1-flash-image`; omit `imageSize` for `gemini-2.5-flash-image` |
+| `1K` | ~1024px (default) | `gemini-3-pro-image`, `gemini-3.1-flash-image`, `gemini-3.1-flash-lite-image` (only 1K); omit `imageSize` for `gemini-2.5-flash-image` |
 | `2K` | ~2048px | `gemini-3-pro-image`, `gemini-3.1-flash-image` |
 | `4K` | ~4096px | `gemini-3-pro-image` or `gemini-3.1-flash-image` |
 

--- a/examples/video-generation.md
+++ b/examples/video-generation.md
@@ -102,7 +102,7 @@ When completed, `check_video` saves files under the configured video output dire
 
 ## Omni Flash: Synchronous Generation and Interactive Editing
 
-`generate_omni_video` uses the non-Veo Gemini Omni Flash model (`gemini-omni-flash-preview`) on the Google AI Studio (Gemini API) backend. Unlike `generate_video`, it is synchronous: a single call returns the finished, saved video, so there is no `operationId` and no `check_video` polling. Output is 720p only, aspect ratio is `16:9` or `9:16`, duration is 3-10 seconds, and a synced audio track is generated automatically.
+`generate_omni_video` uses the non-Veo Gemini Omni Flash model (`gemini-omni-flash-preview`) on the Google AI Studio (Gemini API) backend. Unlike `generate_video`, it is synchronous: a single call returns the finished, saved video, so there is no `operationId` and no `check_video` polling. Output is 720p only, aspect ratio is `16:9` or `9:16`, clips run a few seconds (steer timing within the prompt — there is no duration parameter), and a synced audio track is generated automatically.
 
 Oneshot generation (text-to-video). Add `imagePaths` (max 7, PNG/JPEG/WEBP) for image- or reference-to-video.
 
@@ -111,8 +111,7 @@ Oneshot generation (text-to-video). Add `imagePaths` (max 7, PNG/JPEG/WEBP) for 
   name: "generate_omni_video",
   arguments: {
     prompt: "A cinematic tracking shot through a quiet neon-lit robotics lab, soft ambient hum.",
-    aspectRatio: "16:9",
-    durationSeconds: 8
+    aspectRatio: "16:9"
   }
 }
 ```

--- a/examples/video-generation.md
+++ b/examples/video-generation.md
@@ -99,3 +99,32 @@ Image source fields (`imagePath`, `lastFramePath`, `referenceImagePaths`) accept
 ```
 
 When completed, `check_video` saves files under the configured video output directory and returns saved file paths.
+
+## Omni Flash: Synchronous Generation and Interactive Editing
+
+`generate_omni_video` uses the non-Veo Gemini Omni Flash model (`gemini-omni-flash-preview`) on the Google AI Studio (Gemini API) backend. Unlike `generate_video`, it is synchronous: a single call returns the finished, saved video, so there is no `operationId` and no `check_video` polling. Output is 720p only, aspect ratio is `16:9` or `9:16`, duration is 3-10 seconds, and a synced audio track is generated automatically.
+
+Oneshot generation (text-to-video). Add `imagePaths` (max 7, PNG/JPEG/WEBP) for image- or reference-to-video.
+
+```typescript
+{
+  name: "generate_omni_video",
+  arguments: {
+    prompt: "A cinematic tracking shot through a quiet neon-lit robotics lab, soft ambient hum.",
+    aspectRatio: "16:9",
+    durationSeconds: 8
+  }
+}
+```
+
+The response text includes an `interactionId` and the saved file path. Pass that `interactionId` back as `previousInteractionId` to conversationally edit the same video with a natural-language instruction, with no image re-upload. Chain up to 3 sequential edits.
+
+```typescript
+{
+  name: "generate_omni_video",
+  arguments: {
+    prompt: "Add warm sunrise lighting and slow the camera down.",
+    previousInteractionId: "<interactionId-from-previous-call>"
+  }
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@google/genai": "^2.8.0",
-        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@google/genai": "^2.10.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.3.1",
         "zod": "^4.3.6"
       },
@@ -466,9 +466,9 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.8.0.tgz",
-      "integrity": "sha512-pc2ayxqO5+O7AvnHBqpNHIk7PAZkHZgL31tbyx0gJZBSS9qPYiQoqwK7oYOw/ePmG6QY4EMSu+304vD5QlhXAw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.10.0.tgz",
+      "integrity": "sha512-e4cFxj3tiuMtsgOT4G9c1hXyGJhg7/Buj7VVeBacRY3fRtkRZZ59Q3nuVp2xbq8BGQXLXCDB253qMhklMOeUDg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -502,9 +502,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@google/genai": "^2.8.0",
-    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@google/genai": "^2.10.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.3.1",
     "zod": "^4.3.6"
   },

--- a/src/handlers/OmniVideoHandler.ts
+++ b/src/handlers/OmniVideoHandler.ts
@@ -1,0 +1,54 @@
+import { OmniVideoGenerationInput } from '../schemas/index.js';
+import { GeminiAIService } from '../services/GeminiAIService.js';
+import { GeminiAIConfig } from '../types/index.js';
+import { getDefaultVideoDir, saveVideo, generateVideoFilename } from '../utils/videoSaver.js';
+
+/**
+ * Handles the generate_omni_video tool (Gemini Omni Flash).
+ *
+ * Omni Flash returns the finished video synchronously via the Interactions API,
+ * so unlike the Veo generate_video/check_video pair this handler saves the video
+ * and returns its path in a single call. The interactionId is surfaced so callers
+ * can chain conversational edits by passing it back as previousInteractionId.
+ */
+export class OmniVideoHandler {
+  private geminiService: GeminiAIService;
+  private videoOutputDir: string;
+
+  constructor(geminiService: GeminiAIService, config: GeminiAIConfig) {
+    this.geminiService = geminiService;
+    this.videoOutputDir = config.videoOutputDir || getDefaultVideoDir();
+  }
+
+  getVideoOutputDir(): string {
+    return this.videoOutputDir;
+  }
+
+  async handle(input: OmniVideoGenerationInput): Promise<{ content: Array<{ type: string; text: string }> }> {
+    const result = await this.geminiService.generateOmniVideo(input.prompt, {
+      model: input.model,
+      aspectRatio: input.aspectRatio,
+      durationSeconds: input.durationSeconds,
+      imagePaths: input.imagePaths,
+      previousInteractionId: input.previousInteractionId,
+      systemInstruction: input.systemInstruction,
+      backend: input.backend,
+    });
+
+    const filename = generateVideoFilename(1);
+    const filePath = saveVideo(result.video.data, this.videoOutputDir, filename);
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          status: 'completed',
+          interactionId: result.interactionId,
+          video: { filePath, mimeType: result.video.mimeType },
+          ...(result.text ? { text: result.text } : {}),
+          hint: 'To conversationally edit this video, call generate_omni_video again with previousInteractionId set to the interactionId above.',
+        }),
+      }],
+    };
+  }
+}

--- a/src/handlers/OmniVideoHandler.ts
+++ b/src/handlers/OmniVideoHandler.ts
@@ -28,10 +28,8 @@ export class OmniVideoHandler {
     const result = await this.geminiService.generateOmniVideo(input.prompt, {
       model: input.model,
       aspectRatio: input.aspectRatio,
-      durationSeconds: input.durationSeconds,
       imagePaths: input.imagePaths,
       previousInteractionId: input.previousInteractionId,
-      systemInstruction: input.systemInstruction,
       backend: input.backend,
     });
 

--- a/src/handlers/ReferenceSearchHandler.ts
+++ b/src/handlers/ReferenceSearchHandler.ts
@@ -1,0 +1,45 @@
+import { ReferenceSearchInput } from '../schemas/index.js';
+import { GeminiAIService } from '../services/GeminiAIService.js';
+
+/**
+ * Handles the reference_search tool (AI-assisted, grounded reference search).
+ *
+ * Composes an answer from live web sources using Gemini's Google Search
+ * grounding and returns organized citations (links) plus claim->source supports.
+ * The searchSuggestionsHtml, when present, is Google's required Search
+ * Suggestions markup that callers must display alongside grounded answers.
+ */
+export class ReferenceSearchHandler {
+  private geminiService: GeminiAIService;
+
+  constructor(geminiService: GeminiAIService) {
+    this.geminiService = geminiService;
+  }
+
+  async handle(input: ReferenceSearchInput): Promise<{ content: Array<{ type: string; text: string }> }> {
+    const result = await this.geminiService.referenceSearch(input.prompt, {
+      model: input.model,
+      backend: input.backend,
+      excludeDomains: input.excludeDomains,
+      blockingConfidence: input.blockingConfidence,
+      timeRange: input.timeRange,
+      includeImages: input.includeImages,
+      urls: input.urls,
+      systemInstruction: input.systemInstruction,
+      thinkingLevel: input.thinkingLevel,
+    });
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          answer: result.text,
+          citations: result.citations,
+          supports: result.supports,
+          searchQueries: result.searchQueries,
+          ...(result.searchEntryPoint ? { searchSuggestionsHtml: result.searchEntryPoint } : {}),
+        }, null, 2),
+      }],
+    };
+  }
+}

--- a/src/schemas/index.test.ts
+++ b/src/schemas/index.test.ts
@@ -537,13 +537,11 @@ describe('ReferenceSearchSchema (Vertex default)', () => {
       excludeDomains: ['reddit.com', 'pinterest.com'],
       blockingConfidence: 'medium',
       includeImages: true,
-      urls: ['https://ai.google.dev/gemini-api/docs'],
     });
 
     expect(parsed.excludeDomains).toHaveLength(2);
     expect(parsed.blockingConfidence).toBe('medium');
     expect(parsed.includeImages).toBe(true);
-    expect(parsed.urls).toEqual(['https://ai.google.dev/gemini-api/docs']);
   });
 
   it('rejects timeRange on the Vertex backend', () => {
@@ -553,16 +551,31 @@ describe('ReferenceSearchSchema (Vertex default)', () => {
     })).toThrow(/timeRange is supported by the Google AI Studio backend only/);
   });
 
+  it('rejects urls (URL context) on Vertex but accepts them on Google AI Studio', () => {
+    // URL context is a Gemini API (AI Studio) only tool; Vertex rejects it.
+    expect(() => ReferenceSearchSchema.parse({
+      prompt: 'ground on these pages',
+      urls: ['https://ai.google.dev/gemini-api/docs'],
+    })).toThrow(/urls \(URL context\) is supported by the Google AI Studio backend only/);
+
+    const AiStudio = buildReferenceSearchSchema(false);
+    expect(AiStudio.parse({
+      prompt: 'ground on these pages',
+      urls: ['https://ai.google.dev/gemini-api/docs'],
+    }).urls).toEqual(['https://ai.google.dev/gemini-api/docs']);
+  });
+
   it('rejects more than 2000 excluded domains and more than 20 urls', () => {
     expect(() => ReferenceSearchSchema.parse({
       prompt: 'x',
       excludeDomains: Array.from({ length: 2001 }, (_, i) => `d${i}.com`),
     })).toThrow();
 
-    expect(() => ReferenceSearchSchema.parse({
+    // urls is Google AI Studio only, so exercise the max-20 cap on that backend
+    expect(() => buildReferenceSearchSchema(false).parse({
       prompt: 'x',
       urls: Array.from({ length: 21 }, (_, i) => `https://example.com/${i}`),
-    })).toThrow();
+    })).toThrow(/20 items/);
   });
 
   it('rejects unknown keys and a partial timeRange', () => {

--- a/src/schemas/index.test.ts
+++ b/src/schemas/index.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest';
 import {
   ImageGenerationSchema,
   MusicGenerationSchema,
+  OmniVideoGenerationSchema,
   QuerySchema,
   SpeechGenerationSchema,
   VideoGenerationSchema,
   buildMusicGenerationSchema,
+  buildSpeechGenerationSchema,
   buildVideoGenerationSchema,
 } from './index.js';
 
@@ -112,6 +114,50 @@ describe('ImageGenerationSchema model compatibility', () => {
       prompt: 'edit from this reference',
       imagePaths: ['/tmp/reference.mp3'],
     })).toThrow(/Unsupported image source file type/);
+  });
+
+  it('accepts Nano Banana 2 Lite with 1K and up to 14 references', () => {
+    const parsed = ImageGenerationSchema.parse({
+      prompt: 'fast product shot',
+      model: 'gemini-3.1-flash-lite-image',
+      imageSize: '1K',
+      aspectRatio: '16:9',
+      imagePaths: Array.from({ length: 14 }, (_, index) => `/tmp/ref-${index}.png`),
+    });
+
+    expect(parsed.model).toBe('gemini-3.1-flash-lite-image');
+    expect(parsed.imageSize).toBe('1K');
+    expect(parsed.imagePaths).toHaveLength(14);
+  });
+
+  it('restricts Nano Banana 2 Lite to its supported options', () => {
+    // Lite is 1K only — 2K/4K rejected.
+    expect(() => ImageGenerationSchema.parse({
+      prompt: 'hires lite',
+      model: 'gemini-3.1-flash-lite-image',
+      imageSize: '4K',
+    })).toThrow(/gemini-3\.1-flash-lite-image supports imageSize='1K' only/);
+
+    // 0.5K still requires flash-image.
+    expect(() => ImageGenerationSchema.parse({
+      prompt: 'tiny lite',
+      model: 'gemini-3.1-flash-lite-image',
+      imageSize: '0.5K',
+    })).toThrow(/gemini-3\.1-flash-image/);
+
+    // Extreme aspect ratios still require flash-image.
+    expect(() => ImageGenerationSchema.parse({
+      prompt: 'wide lite',
+      model: 'gemini-3.1-flash-lite-image',
+      aspectRatio: '8:1',
+    })).toThrow(/gemini-3\.1-flash-image/);
+
+    // Lite does not support thinkingLevel.
+    expect(() => ImageGenerationSchema.parse({
+      prompt: 'thinking lite',
+      model: 'gemini-3.1-flash-lite-image',
+      thinkingLevel: 'high',
+    })).toThrow(/gemini-3\.1-flash-image/);
   });
 });
 
@@ -389,6 +435,87 @@ describe('SpeechGenerationSchema TTS models', () => {
         { speaker: 'Bob', voiceName: 'Puck' },
       ],
     })).toThrow(/voiceName cannot be used with speakers/);
+  });
+});
+
+describe('buildSpeechGenerationSchema per-backend TTS models', () => {
+  const VertexSpeech = buildSpeechGenerationSchema(true);
+  const AiStudioSpeech = buildSpeechGenerationSchema(false);
+  const DualSpeech = buildSpeechGenerationSchema(true, ['vertex', 'ai-studio']);
+
+  it('accepts Vertex GA TTS ids on the Vertex backend', () => {
+    expect(VertexSpeech.parse({ prompt: 'hi', model: 'gemini-2.5-flash-tts' }).model)
+      .toBe('gemini-2.5-flash-tts');
+    expect(VertexSpeech.parse({ prompt: 'hi', model: 'gemini-2.5-pro-tts' }).model)
+      .toBe('gemini-2.5-pro-tts');
+  });
+
+  it('accepts Google AI Studio preview TTS ids on the ai-studio backend', () => {
+    expect(AiStudioSpeech.parse({ prompt: 'hi', model: 'gemini-2.5-flash-preview-tts' }).model)
+      .toBe('gemini-2.5-flash-preview-tts');
+    expect(AiStudioSpeech.parse({ prompt: 'hi', model: 'gemini-2.5-pro-preview-tts' }).model)
+      .toBe('gemini-2.5-pro-preview-tts');
+  });
+
+  it('accepts the shared gemini-3.1 TTS id on both backends', () => {
+    expect(VertexSpeech.parse({ prompt: 'hi', model: 'gemini-3.1-flash-tts-preview' }).model)
+      .toBe('gemini-3.1-flash-tts-preview');
+    expect(AiStudioSpeech.parse({ prompt: 'hi', model: 'gemini-3.1-flash-tts-preview' }).model)
+      .toBe('gemini-3.1-flash-tts-preview');
+  });
+
+  it('rejects a TTS id that does not match the selected backend', () => {
+    // dual defaults to vertex; an AI-Studio-only preview id must be rejected there
+    expect(() => DualSpeech.parse({ prompt: 'hi', model: 'gemini-2.5-flash-preview-tts' }))
+      .toThrow(/does not match the selected backend/);
+    expect(DualSpeech.parse({ prompt: 'hi', backend: 'ai-studio', model: 'gemini-2.5-flash-preview-tts' }).model)
+      .toBe('gemini-2.5-flash-preview-tts');
+  });
+});
+
+describe('OmniVideoGenerationSchema', () => {
+  it('accepts a oneshot generation with reference images', () => {
+    const parsed = OmniVideoGenerationSchema.parse({
+      prompt: 'a fox darting through snow',
+      aspectRatio: '9:16',
+      durationSeconds: 8,
+      imagePaths: ['/tmp/fox.png', '/tmp/snow.jpg'],
+    });
+
+    expect(parsed.aspectRatio).toBe('9:16');
+    expect(parsed.durationSeconds).toBe(8);
+    expect(parsed.imagePaths).toHaveLength(2);
+  });
+
+  it('accepts an interactive edit via previousInteractionId', () => {
+    const parsed = OmniVideoGenerationSchema.parse({
+      prompt: 'make the sky sunset orange',
+      previousInteractionId: 'interaction-123',
+    });
+
+    expect(parsed.previousInteractionId).toBe('interaction-123');
+  });
+
+  it('rejects out-of-range duration, unsupported ratios, and too many references', () => {
+    expect(() => OmniVideoGenerationSchema.parse({
+      prompt: 'x', durationSeconds: 12,
+    })).toThrow();
+
+    expect(() => OmniVideoGenerationSchema.parse({
+      prompt: 'x', aspectRatio: '1:1',
+    })).toThrow();
+
+    expect(() => OmniVideoGenerationSchema.parse({
+      prompt: 'x',
+      imagePaths: Array.from({ length: 8 }, (_, index) => `/tmp/ref-${index}.png`),
+    })).toThrow();
+  });
+
+  it('rejects unsupported image source file types', () => {
+    expect(() => OmniVideoGenerationSchema.parse({
+      prompt: 'x',
+      imagePaths: ['/tmp/ref.heic'],
+    })).toThrow(/Unsupported Veo image source file type/);
   });
 });
 

--- a/src/schemas/index.test.ts
+++ b/src/schemas/index.test.ts
@@ -480,12 +480,10 @@ describe('OmniVideoGenerationSchema', () => {
     const parsed = OmniVideoGenerationSchema.parse({
       prompt: 'a fox darting through snow',
       aspectRatio: '9:16',
-      durationSeconds: 8,
       imagePaths: ['/tmp/fox.png', '/tmp/snow.jpg'],
     });
 
     expect(parsed.aspectRatio).toBe('9:16');
-    expect(parsed.durationSeconds).toBe(8);
     expect(parsed.imagePaths).toHaveLength(2);
   });
 
@@ -498,11 +496,7 @@ describe('OmniVideoGenerationSchema', () => {
     expect(parsed.previousInteractionId).toBe('interaction-123');
   });
 
-  it('rejects out-of-range duration, unsupported ratios, and too many references', () => {
-    expect(() => OmniVideoGenerationSchema.parse({
-      prompt: 'x', durationSeconds: 12,
-    })).toThrow();
-
+  it('rejects unsupported ratios and too many references', () => {
     expect(() => OmniVideoGenerationSchema.parse({
       prompt: 'x', aspectRatio: '1:1',
     })).toThrow();
@@ -510,6 +504,16 @@ describe('OmniVideoGenerationSchema', () => {
     expect(() => OmniVideoGenerationSchema.parse({
       prompt: 'x',
       imagePaths: Array.from({ length: 8 }, (_, index) => `/tmp/ref-${index}.png`),
+    })).toThrow();
+  });
+
+  it('rejects the removed duration and systemInstruction fields (Omni Flash unsupported)', () => {
+    expect(() => OmniVideoGenerationSchema.parse({
+      prompt: 'x', durationSeconds: 6,
+    })).toThrow();
+
+    expect(() => OmniVideoGenerationSchema.parse({
+      prompt: 'x', systemInstruction: 'be cinematic',
     })).toThrow();
   });
 

--- a/src/schemas/index.test.ts
+++ b/src/schemas/index.test.ts
@@ -4,9 +4,11 @@ import {
   MusicGenerationSchema,
   OmniVideoGenerationSchema,
   QuerySchema,
+  ReferenceSearchSchema,
   SpeechGenerationSchema,
   VideoGenerationSchema,
   buildMusicGenerationSchema,
+  buildReferenceSearchSchema,
   buildSpeechGenerationSchema,
   buildVideoGenerationSchema,
 } from './index.js';
@@ -516,6 +518,112 @@ describe('OmniVideoGenerationSchema', () => {
       prompt: 'x',
       imagePaths: ['/tmp/ref.heic'],
     })).toThrow(/Unsupported Veo image source file type/);
+  });
+});
+
+describe('ReferenceSearchSchema (Vertex default)', () => {
+  it('accepts a minimal prompt-only request', () => {
+    expect(ReferenceSearchSchema.parse({ prompt: 'latest Gemini 3 pricing' }).prompt)
+      .toBe('latest Gemini 3 pricing');
+  });
+
+  it('accepts Vertex-only search-scope tuning (excludeDomains + blockingConfidence)', () => {
+    const parsed = ReferenceSearchSchema.parse({
+      prompt: 'best practices for MCP servers',
+      excludeDomains: ['reddit.com', 'pinterest.com'],
+      blockingConfidence: 'medium',
+      includeImages: true,
+      urls: ['https://ai.google.dev/gemini-api/docs'],
+    });
+
+    expect(parsed.excludeDomains).toHaveLength(2);
+    expect(parsed.blockingConfidence).toBe('medium');
+    expect(parsed.includeImages).toBe(true);
+    expect(parsed.urls).toEqual(['https://ai.google.dev/gemini-api/docs']);
+  });
+
+  it('rejects timeRange on the Vertex backend', () => {
+    expect(() => ReferenceSearchSchema.parse({
+      prompt: 'recent news',
+      timeRange: { startTime: '2026-01-01T00:00:00Z', endTime: '2026-07-01T00:00:00Z' },
+    })).toThrow(/timeRange is supported by the Google AI Studio backend only/);
+  });
+
+  it('rejects more than 2000 excluded domains and more than 20 urls', () => {
+    expect(() => ReferenceSearchSchema.parse({
+      prompt: 'x',
+      excludeDomains: Array.from({ length: 2001 }, (_, i) => `d${i}.com`),
+    })).toThrow();
+
+    expect(() => ReferenceSearchSchema.parse({
+      prompt: 'x',
+      urls: Array.from({ length: 21 }, (_, i) => `https://example.com/${i}`),
+    })).toThrow();
+  });
+
+  it('rejects unknown keys and a partial timeRange', () => {
+    expect(() => ReferenceSearchSchema.parse({
+      prompt: 'x',
+      maxResults: 5,
+    })).toThrow(/Unrecognized key/);
+
+    const AiStudio = buildReferenceSearchSchema(false);
+    expect(() => AiStudio.parse({
+      prompt: 'x',
+      timeRange: { startTime: '2026-01-01T00:00:00Z' },
+    })).toThrow();
+  });
+});
+
+describe('buildReferenceSearchSchema per-backend tuning', () => {
+  const AiStudio = buildReferenceSearchSchema(false);
+  const Dual = buildReferenceSearchSchema(true, ['vertex', 'ai-studio']);
+
+  it('accepts timeRange on the Google AI Studio backend', () => {
+    const parsed = AiStudio.parse({
+      prompt: 'headlines this month',
+      timeRange: { startTime: '2026-06-01T00:00:00Z', endTime: '2026-07-01T00:00:00Z' },
+    });
+
+    expect(parsed.timeRange?.startTime).toBe('2026-06-01T00:00:00Z');
+  });
+
+  it('rejects Vertex-only tuning on the Google AI Studio backend', () => {
+    expect(() => AiStudio.parse({
+      prompt: 'x',
+      excludeDomains: ['reddit.com'],
+    })).toThrow(/excludeDomains and blockingConfidence are supported by the Vertex AI backend only/);
+
+    expect(() => AiStudio.parse({
+      prompt: 'x',
+      blockingConfidence: 'high',
+    })).toThrow(/Vertex AI backend only/);
+  });
+
+  it('gates tuning by the per-request backend override in dual mode', () => {
+    // default backend is vertex -> timeRange rejected without an override
+    expect(() => Dual.parse({
+      prompt: 'x',
+      timeRange: { startTime: '2026-01-01T00:00:00Z', endTime: '2026-07-01T00:00:00Z' },
+    })).toThrow(/Google AI Studio backend only/);
+
+    // override to ai-studio -> timeRange allowed, excludeDomains rejected
+    expect(Dual.parse({
+      prompt: 'x',
+      backend: 'ai-studio',
+      timeRange: { startTime: '2026-01-01T00:00:00Z', endTime: '2026-07-01T00:00:00Z' },
+    }).backend).toBe('ai-studio');
+
+    expect(() => Dual.parse({
+      prompt: 'x',
+      backend: 'ai-studio',
+      excludeDomains: ['reddit.com'],
+    })).toThrow(/Vertex AI backend only/);
+  });
+
+  it('rejects a backend value that is not configured', () => {
+    const VertexOnly = buildReferenceSearchSchema(true, ['vertex']);
+    expect(() => VertexOnly.parse({ prompt: 'x', backend: 'ai-studio' })).toThrow();
   });
 });
 

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -489,6 +489,7 @@ export const OmniVideoGenerationSchema = z.object({
 // tuning is backend-asymmetric per the @google/genai GoogleSearch tool:
 //   - excludeDomains / blockingConfidence: Vertex AI only
 //   - timeRange (timeRangeFilter): Google AI Studio (Gemini API) only
+//   - urls (URL context tool): Google AI Studio (Gemini API) only
 const ALLOWED_BLOCKING_CONFIDENCE = ['low', 'medium', 'high'] as const;
 
 const ReferenceTimeRangeSchema = z.object({
@@ -507,7 +508,7 @@ export function buildReferenceSearchSchema(
   return z.object({
     prompt: z.string().describe("Research question or topic to answer from live web sources."),
     backend: z.enum(availableBackends as [Backend, ...Backend[]]).optional()
-      .describe(`Backend for this request (default: ${defaultBackend}; available: ${availableBackends.join(', ')}). Search-scope tuning differs: Vertex AI supports excludeDomains/blockingConfidence; Google AI Studio supports timeRange.`),
+      .describe(`Backend for this request (default: ${defaultBackend}; available: ${availableBackends.join(', ')}). Search-scope tuning differs: Vertex AI supports excludeDomains/blockingConfidence; Google AI Studio supports timeRange and urls (URL context).`),
     model: z.string().optional()
       .describe("Optional Gemini model override; must support Google Search grounding (default: server model)."),
     excludeDomains: z.array(z.string().min(1)).max(2000).optional()
@@ -519,7 +520,7 @@ export function buildReferenceSearchSchema(
     includeImages: z.boolean().optional()
       .describe("Also enable image-search grounding in addition to web search."),
     urls: z.array(z.string().min(1)).max(20).optional()
-      .describe("Specific http(s) URLs to ground the answer on via URL context (max 20; both backends)."),
+      .describe("Specific http(s) URLs to ground the answer on via URL context (max 20). Google AI Studio backend only; the URL context tool is not available on Vertex AI."),
     systemInstruction: z.string().optional()
       .describe("Optional system instruction to steer the tone, depth, or scope of the composed answer."),
     thinkingLevel: z.enum(['minimal', 'low', 'medium', 'high', 'MINIMAL', 'LOW', 'MEDIUM', 'HIGH']).optional()
@@ -530,6 +531,9 @@ export function buildReferenceSearchSchema(
   ).refine(
     (data) => !isVertex(data) || data.timeRange === undefined,
     { message: "timeRange is supported by the Google AI Studio backend only" }
+  ).refine(
+    (data) => !isVertex(data) || !data.urls || data.urls.length === 0,
+    { message: "urls (URL context) is supported by the Google AI Studio backend only; the URL context tool is not available on Vertex AI" }
   );
 }
 

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -474,17 +474,13 @@ export const OmniVideoGenerationSchema = z.object({
   model: z.enum(ALLOWED_OMNI_VIDEO_MODELS).optional()
     .describe("Omni video model (default: gemini-omni-flash-preview)"),
   backend: z.enum(['vertex', 'ai-studio']).optional()
-    .describe("Optional backend override. Gemini Omni Flash runs on the Google AI Studio (Gemini API) backend; Vertex AI availability is rolling out."),
+    .describe("Optional backend override. Gemini Omni Flash runs on the Google AI Studio (Gemini API) backend and defaults to it; Vertex AI is not supported yet (availability rolling out)."),
   aspectRatio: z.enum(['16:9', '9:16']).optional()
-    .describe("Aspect ratio (default: 16:9). Omni Flash supports 16:9 and 9:16 only."),
-  durationSeconds: z.number().int().min(3).max(10).optional()
-    .describe("Video duration in seconds (3-10; default: model default). Output is 720p only."),
+    .describe("Aspect ratio (default: 16:9). Omni Flash supports 16:9 and 9:16 only. Output is 720p only; clips run a few seconds — steer timing within the prompt."),
   imagePaths: z.array(VeoImageInputPathSchema).max(7).optional()
     .describe(`Local file paths of source/reference images for image-to-video or reference-to-video (max 7). Supported file types: ${VEO_IMAGE_INPUT_FILE_TYPES}. Omit for interactive edits — previousInteractionId reuses the prior video without re-uploading.`),
   previousInteractionId: z.string().min(1).optional()
     .describe("Interaction ID returned by a prior generate_omni_video call. When set, conversationally edits that video (no image re-upload) instead of generating a new one. Chain up to 3 sequential edits."),
-  systemInstruction: z.string().optional()
-    .describe("Optional system instruction to steer generation or editing"),
 }).strict();
 
 // AI-assisted reference search. Composes an answer from live web sources via

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -487,6 +487,58 @@ export const OmniVideoGenerationSchema = z.object({
     .describe("Optional system instruction to steer generation or editing"),
 }).strict();
 
+// AI-assisted reference search. Composes an answer from live web sources via
+// Gemini's Google Search grounding (config.tools = [{ googleSearch }]) and
+// returns organized citations from response groundingMetadata. Search-scope
+// tuning is backend-asymmetric per the @google/genai GoogleSearch tool:
+//   - excludeDomains / blockingConfidence: Vertex AI only
+//   - timeRange (timeRangeFilter): Google AI Studio (Gemini API) only
+const ALLOWED_BLOCKING_CONFIDENCE = ['low', 'medium', 'high'] as const;
+
+const ReferenceTimeRangeSchema = z.object({
+  startTime: z.string().min(1)
+    .describe("Inclusive RFC 3339 start timestamp, e.g. '2026-01-01T00:00:00Z'"),
+  endTime: z.string().min(1)
+    .describe("Exclusive RFC 3339 end timestamp, e.g. '2026-07-01T00:00:00Z'"),
+}).strict();
+
+export function buildReferenceSearchSchema(
+  useVertexAI: boolean = true,
+  availableBackends: Backend[] = [useVertexAI ? 'vertex' : 'ai-studio'],
+) {
+  const defaultBackend: Backend = useVertexAI ? 'vertex' : 'ai-studio';
+  const isVertex = (data: { backend?: Backend }): boolean => (data.backend ?? defaultBackend) === 'vertex';
+  return z.object({
+    prompt: z.string().describe("Research question or topic to answer from live web sources."),
+    backend: z.enum(availableBackends as [Backend, ...Backend[]]).optional()
+      .describe(`Backend for this request (default: ${defaultBackend}; available: ${availableBackends.join(', ')}). Search-scope tuning differs: Vertex AI supports excludeDomains/blockingConfidence; Google AI Studio supports timeRange.`),
+    model: z.string().optional()
+      .describe("Optional Gemini model override; must support Google Search grounding (default: server model)."),
+    excludeDomains: z.array(z.string().min(1)).max(2000).optional()
+      .describe("Domains to exclude from search results, e.g. ['reddit.com','pinterest.com'] (search-scope tuning; max 2000). Vertex AI backend only."),
+    blockingConfidence: z.enum(ALLOWED_BLOCKING_CONFIDENCE).optional()
+      .describe("Block risky/low-quality sites at or above this confidence ('low' is the most aggressive). Vertex AI backend only."),
+    timeRange: ReferenceTimeRangeSchema.optional()
+      .describe("Restrict results to a publish-time window for recency tuning; startTime and endTime are both required. Google AI Studio backend only."),
+    includeImages: z.boolean().optional()
+      .describe("Also enable image-search grounding in addition to web search."),
+    urls: z.array(z.string().min(1)).max(20).optional()
+      .describe("Specific http(s) URLs to ground the answer on via URL context (max 20; both backends)."),
+    systemInstruction: z.string().optional()
+      .describe("Optional system instruction to steer the tone, depth, or scope of the composed answer."),
+    thinkingLevel: z.enum(['minimal', 'low', 'medium', 'high', 'MINIMAL', 'LOW', 'MEDIUM', 'HIGH']).optional()
+      .describe("Optional Gemini 3 thinking level override for the reasoning depth of the answer."),
+  }).strict().refine(
+    (data) => isVertex(data) || (!data.excludeDomains && !data.blockingConfidence),
+    { message: "excludeDomains and blockingConfidence are supported by the Vertex AI backend only" }
+  ).refine(
+    (data) => !isVertex(data) || data.timeRange === undefined,
+    { message: "timeRange is supported by the Google AI Studio backend only" }
+  );
+}
+
+export const ReferenceSearchSchema = buildReferenceSearchSchema(true);
+
 export type QueryInput = z.infer<typeof QuerySchema>;
 export type SearchInput = z.infer<typeof SearchSchema>;
 export type FetchInput = z.infer<typeof FetchSchema>;
@@ -495,6 +547,7 @@ export type SpeechGenerationInput = z.infer<typeof SpeechGenerationSchema>;
 export type MusicGenerationInput = z.infer<ReturnType<typeof buildMusicGenerationSchema>>;
 export type VideoGenerationInput = z.infer<typeof VideoGenerationSchema>;
 export type OmniVideoGenerationInput = z.infer<typeof OmniVideoGenerationSchema>;
+export type ReferenceSearchInput = z.infer<ReturnType<typeof buildReferenceSearchSchema>>;
 
 export const CheckVideoSchema = z.object({
   operationId: z.string().describe("Operation ID returned by generate_video"),

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -76,6 +76,7 @@ export const FetchSchema = z.object({
 const ALLOWED_IMAGE_MODELS = [
   'gemini-3-pro-image',
   'gemini-3.1-flash-image',
+  'gemini-3.1-flash-lite-image',
   'gemini-2.5-flash-image',
 ] as const;
 
@@ -94,7 +95,7 @@ export const ImageGenerationSchema = z.object({
   aspectRatio: z.enum(ALLOWED_IMAGE_ASPECT_RATIOS).optional()
     .describe("Aspect ratio (default: 1:1; 1:4, 1:8, 4:1, and 8:1 require gemini-3.1-flash-image)"),
   imageSize: z.enum(['0.5K', '1K', '2K', '4K']).optional()
-    .describe("Resolution (0.5K requires gemini-3.1-flash-image, default: 1K)"),
+    .describe("Resolution (0.5K requires gemini-3.1-flash-image; gemini-3.1-flash-lite-image supports 1K only; default: 1K)"),
   imagePaths: z.array(GeminiImageInputPathSchema).max(14).optional()
     .describe(`Local file paths of reference images to include as input (max 14; e.g., for image editing or style transfer). Supported file types: ${GEMINI_IMAGE_INPUT_FILE_TYPES}. Audio/video files are not accepted.`),
   systemInstruction: z.string().optional()
@@ -132,6 +133,11 @@ export const ImageGenerationSchema = z.object({
     return data.model !== 'gemini-2.5-flash-image' || !data.imagePaths || data.imagePaths.length <= 3;
   },
   { message: "gemini-2.5-flash-image supports at most 3 reference images" }
+).refine(
+  (data) => {
+    return data.model !== 'gemini-3.1-flash-lite-image' || data.imageSize === undefined || data.imageSize === '1K';
+  },
+  { message: "gemini-3.1-flash-lite-image supports imageSize='1K' only; omit imageSize for its default 1K output" }
 );
 
 const ALLOWED_VERTEX_VIDEO_MODELS = [
@@ -154,33 +160,66 @@ export function getDefaultVideoModel(useVertexAI: boolean): string {
   return useVertexAI ? ALLOWED_VERTEX_VIDEO_MODELS[0] : ALLOWED_GEMINI_API_VIDEO_MODELS[0];
 }
 
-const ALLOWED_SPEECH_MODELS = [
+// gemini-3.1-flash-tts-preview uses the SAME id on both backends. The 2.5 TTS
+// tiers differ by backend: Google AI Studio exposes '-preview-tts' preview ids,
+// Vertex AI / Cloud Text-to-Speech exposes GA '-tts' ids.
+const ALLOWED_VERTEX_SPEECH_MODELS = [
+  'gemini-3.1-flash-tts-preview',
+  'gemini-2.5-flash-tts',
+  'gemini-2.5-pro-tts',
+] as const;
+
+const ALLOWED_GEMINI_API_SPEECH_MODELS = [
   'gemini-3.1-flash-tts-preview',
   'gemini-2.5-flash-preview-tts',
   'gemini-2.5-pro-preview-tts',
 ] as const;
+
+export function getAllowedSpeechModels(useVertexAI: boolean): readonly string[] {
+  return useVertexAI ? ALLOWED_VERTEX_SPEECH_MODELS : ALLOWED_GEMINI_API_SPEECH_MODELS;
+}
 
 const SpeechSpeakerSchema = z.object({
   speaker: z.string().min(1).describe("Speaker name exactly as it appears in the prompt"),
   voiceName: z.string().min(1).describe("Prebuilt voice name for this speaker"),
 }).strict();
 
-export const SpeechGenerationSchema = z.object({
-  prompt: z.string().describe("Text or transcript to synthesize as speech. Gemini TTS is text-only input; audio/image/video reference files are not accepted."),
-  model: z.enum(ALLOWED_SPEECH_MODELS).optional()
-    .describe("Speech model (default: gemini-3.1-flash-tts-preview)"),
-  backend: z.enum(['vertex', 'ai-studio']).optional()
-    .describe("Optional backend override ('vertex' | 'ai-studio'); defaults to the server's configured backend"),
-  voiceName: z.string().min(1).optional()
-    .describe("Prebuilt voice name for single-speaker TTS (default: Kore)"),
-  languageCode: z.string().min(2).optional()
-    .describe("Optional BCP-47 language code for speech synthesis"),
-  speakers: z.array(SpeechSpeakerSchema).length(2).optional()
-    .describe("Exactly two speaker voice configs for multi-speaker TTS"),
-}).strict().refine(
-  (data) => !data.voiceName || !data.speakers,
-  { message: "voiceName cannot be used with speakers; set voiceName per speaker instead" }
-);
+export function buildSpeechGenerationSchema(
+  useVertexAI: boolean = true,
+  availableBackends: Backend[] = [useVertexAI ? 'vertex' : 'ai-studio'],
+) {
+  const defaultBackend: Backend = useVertexAI ? 'vertex' : 'ai-studio';
+  const dual = availableBackends.length > 1;
+  const allowedSpeechModels = (dual
+    ? Array.from(new Set([...ALLOWED_VERTEX_SPEECH_MODELS, ...ALLOWED_GEMINI_API_SPEECH_MODELS]))
+    : (useVertexAI ? ALLOWED_VERTEX_SPEECH_MODELS : ALLOWED_GEMINI_API_SPEECH_MODELS)
+  ) as [string, ...string[]];
+  const effBackend = (data: { backend?: Backend }): Backend => data.backend ?? defaultBackend;
+  const modelsForBackend = (b: Backend): readonly string[] =>
+    b === 'vertex' ? ALLOWED_VERTEX_SPEECH_MODELS : ALLOWED_GEMINI_API_SPEECH_MODELS;
+
+  return z.object({
+    prompt: z.string().describe("Text or transcript to synthesize as speech. Gemini TTS is text-only input; audio/image/video reference files are not accepted."),
+    model: z.enum(allowedSpeechModels).optional()
+      .describe("Speech model (default: gemini-3.1-flash-tts-preview, valid on both backends). The 2.5 tiers differ by backend: Vertex AI uses gemini-2.5-flash-tts/gemini-2.5-pro-tts; Google AI Studio uses gemini-2.5-flash-preview-tts/gemini-2.5-pro-preview-tts."),
+    backend: z.enum(availableBackends as [Backend, ...Backend[]]).optional()
+      .describe(`Backend for this request (default: ${defaultBackend}; available: ${availableBackends.join(', ')}). gemini-3.1-flash-tts-preview works on both; the 2.5 TTS ids differ per backend.`),
+    voiceName: z.string().min(1).optional()
+      .describe("Prebuilt voice name for single-speaker TTS (default: Kore)"),
+    languageCode: z.string().min(2).optional()
+      .describe("Optional BCP-47 language code for speech synthesis"),
+    speakers: z.array(SpeechSpeakerSchema).length(2).optional()
+      .describe("Exactly two speaker voice configs for multi-speaker TTS"),
+  }).strict().refine(
+    (data) => !data.model || modelsForBackend(effBackend(data)).includes(data.model),
+    { message: "speech model does not match the selected backend; Vertex AI uses gemini-2.5-flash-tts/gemini-2.5-pro-tts, Google AI Studio uses gemini-2.5-flash-preview-tts/gemini-2.5-pro-preview-tts (gemini-3.1-flash-tts-preview works on both)" }
+  ).refine(
+    (data) => !data.voiceName || !data.speakers,
+    { message: "voiceName cannot be used with speakers; set voiceName per speaker instead" }
+  );
+}
+
+export const SpeechGenerationSchema = buildSpeechGenerationSchema(true);
 
 const ALLOWED_MUSIC_MODELS = [
   'lyria-3-clip-preview',
@@ -418,6 +457,36 @@ export function buildVideoGenerationSchema(
 
 export const VideoGenerationSchema = buildVideoGenerationSchema(true);
 
+// Gemini Omni Flash is a NON-Veo video model invoked through the Interactions API
+// (client.interactions.create), not the Veo generateVideos long-running-operation
+// pipeline. It returns the finished video synchronously (no check_video polling)
+// and supports stateful conversational editing via previousInteractionId.
+const ALLOWED_OMNI_VIDEO_MODELS = [
+  'gemini-omni-flash-preview',
+] as const;
+
+export const OMNI_VIDEO_INPUT_FILE_TYPES = VEO_IMAGE_INPUT_FILE_TYPES;
+
+export const OmniVideoGenerationSchema = z.object({
+  prompt: z.string().describe(
+    "Video prompt for a new generation (oneshot), or a natural-language edit instruction when previousInteractionId is set (interactive editing). Describe dialogue/SFX/ambience as text; audio reference files are not accepted."
+  ),
+  model: z.enum(ALLOWED_OMNI_VIDEO_MODELS).optional()
+    .describe("Omni video model (default: gemini-omni-flash-preview)"),
+  backend: z.enum(['vertex', 'ai-studio']).optional()
+    .describe("Optional backend override. Gemini Omni Flash runs on the Google AI Studio (Gemini API) backend; Vertex AI availability is rolling out."),
+  aspectRatio: z.enum(['16:9', '9:16']).optional()
+    .describe("Aspect ratio (default: 16:9). Omni Flash supports 16:9 and 9:16 only."),
+  durationSeconds: z.number().int().min(3).max(10).optional()
+    .describe("Video duration in seconds (3-10; default: model default). Output is 720p only."),
+  imagePaths: z.array(VeoImageInputPathSchema).max(7).optional()
+    .describe(`Local file paths of source/reference images for image-to-video or reference-to-video (max 7). Supported file types: ${VEO_IMAGE_INPUT_FILE_TYPES}. Omit for interactive edits — previousInteractionId reuses the prior video without re-uploading.`),
+  previousInteractionId: z.string().min(1).optional()
+    .describe("Interaction ID returned by a prior generate_omni_video call. When set, conversationally edits that video (no image re-upload) instead of generating a new one. Chain up to 3 sequential edits."),
+  systemInstruction: z.string().optional()
+    .describe("Optional system instruction to steer generation or editing"),
+}).strict();
+
 export type QueryInput = z.infer<typeof QuerySchema>;
 export type SearchInput = z.infer<typeof SearchSchema>;
 export type FetchInput = z.infer<typeof FetchSchema>;
@@ -425,6 +494,7 @@ export type ImageGenerationInput = z.infer<typeof ImageGenerationSchema>;
 export type SpeechGenerationInput = z.infer<typeof SpeechGenerationSchema>;
 export type MusicGenerationInput = z.infer<ReturnType<typeof buildMusicGenerationSchema>>;
 export type VideoGenerationInput = z.infer<typeof VideoGenerationSchema>;
+export type OmniVideoGenerationInput = z.infer<typeof OmniVideoGenerationSchema>;
 
 export const CheckVideoSchema = z.object({
   operationId: z.string().describe("Operation ID returned by generate_video"),

--- a/src/server/GeminiAIMCPServer.test.ts
+++ b/src/server/GeminiAIMCPServer.test.ts
@@ -134,6 +134,14 @@ vi.mock('../handlers/OmniVideoHandler.js', () => ({
   },
 }));
 
+const mockReferenceSearchHandle = vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+vi.mock('../handlers/ReferenceSearchHandler.js', () => ({
+  ReferenceSearchHandler: class {
+    handle = mockReferenceSearchHandle;
+    constructor() {}
+  },
+}));
+
 vi.mock('../utils/imageSaver.js', () => ({
   getDefaultImageDir: vi.fn().mockReturnValue('/tmp/images'),
   saveImage: vi.fn(),
@@ -186,6 +194,7 @@ describe('GeminiAIMCPServer generate_image wiring', () => {
     mockSpeechGenHandle.mockClear();
     mockMusicGenHandle.mockClear();
     mockOmniVideoHandle.mockClear();
+    mockReferenceSearchHandle.mockClear();
     mcpServer = new GeminiAIMCPServer(createTestConfig());
     // Access the internal Server mock instance via the private field
     const internalServer = (mcpServer as any).server;
@@ -406,6 +415,52 @@ describe('GeminiAIMCPServer generate_image wiring', () => {
     expect(errorBody.tool).toBe('generate_music');
     expect(errorBody.errorType).toBe('validation_error');
     expect(errorBody.issues[0].message).toMatch(/lyria-3-pro-preview/);
+  });
+
+  it('reference_search tool is exposed and routed to ReferenceSearchHandler', async () => {
+    const result = await listHandler();
+    const refTool = result.tools.find((t: any) => t.name === 'reference_search');
+
+    expect(refTool).toBeDefined();
+    expect(refTool.inputSchema.required).toContain('prompt');
+    expect(refTool.inputSchema.properties.excludeDomains.maxItems).toBe(2000);
+    expect(refTool.inputSchema.properties.blockingConfidence.enum).toEqual(['low', 'medium', 'high']);
+    expect(refTool.inputSchema.properties.timeRange.required).toEqual(['startTime', 'endTime']);
+    expect(refTool.inputSchema.properties.urls.maxItems).toBe(20);
+    expect(refTool.inputSchema.properties.includeImages.type).toBe('boolean');
+    expect(refTool.inputSchema.properties.thinkingLevel.enum).toContain('high');
+    expect(refTool.description).toContain('citations');
+    expect(refTool.description).toContain('searchSuggestionsHtml');
+
+    await callHandler({
+      params: {
+        name: 'reference_search',
+        arguments: { prompt: 'when did Gemini 3 launch?', excludeDomains: ['reddit.com'] },
+      },
+    });
+
+    expect(mockReferenceSearchHandle).toHaveBeenCalledWith({
+      prompt: 'when did Gemini 3 launch?',
+      excludeDomains: ['reddit.com'],
+    });
+  });
+
+  it('rejects Vertex-only reference_search tuning on the Google AI Studio backend', async () => {
+    const aiStudioServer = new GeminiAIMCPServer(createTestConfig({ useVertexAI: false }));
+    const handlers = getHandlers((aiStudioServer as any).server);
+
+    const invalidResult = await handlers.callHandler({
+      params: {
+        name: 'reference_search',
+        arguments: { prompt: 'recent news', excludeDomains: ['reddit.com'] },
+      },
+    });
+    const errorBody = JSON.parse(invalidResult.content[0].text);
+
+    expect(invalidResult.isError).toBe(true);
+    expect(errorBody.tool).toBe('reference_search');
+    expect(errorBody.errorType).toBe('validation_error');
+    expect(errorBody.issues[0].message).toMatch(/Vertex AI backend only/);
   });
 
   it('returns structured error content for handler failures', async () => {

--- a/src/server/GeminiAIMCPServer.test.ts
+++ b/src/server/GeminiAIMCPServer.test.ts
@@ -125,6 +125,15 @@ vi.mock('../handlers/VideoGenerationHandler.js', () => ({
   },
 }));
 
+const mockOmniVideoHandle = vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+vi.mock('../handlers/OmniVideoHandler.js', () => ({
+  OmniVideoHandler: class {
+    handle = mockOmniVideoHandle;
+    getVideoOutputDir = vi.fn().mockReturnValue('/tmp/videos');
+    constructor() {}
+  },
+}));
+
 vi.mock('../utils/imageSaver.js', () => ({
   getDefaultImageDir: vi.fn().mockReturnValue('/tmp/images'),
   saveImage: vi.fn(),
@@ -176,6 +185,7 @@ describe('GeminiAIMCPServer generate_image wiring', () => {
     mockImageGenHandle.mockClear();
     mockSpeechGenHandle.mockClear();
     mockMusicGenHandle.mockClear();
+    mockOmniVideoHandle.mockClear();
     mcpServer = new GeminiAIMCPServer(createTestConfig());
     // Access the internal Server mock instance via the private field
     const internalServer = (mcpServer as any).server;
@@ -206,6 +216,7 @@ describe('GeminiAIMCPServer generate_image wiring', () => {
     expect(imageGenTool.inputSchema.properties.model.enum).toEqual([
       'gemini-3-pro-image',
       'gemini-3.1-flash-image',
+      'gemini-3.1-flash-lite-image',
       'gemini-2.5-flash-image',
     ]);
     expect(imageGenTool.inputSchema.properties.aspectRatio.enum).toContain('1:4');
@@ -242,10 +253,11 @@ describe('GeminiAIMCPServer generate_image wiring', () => {
 
     expect(speechTool).toBeDefined();
     expect(speechTool.inputSchema.required).toContain('prompt');
+    // Vertex mode (createTestConfig useVertexAI: true) advertises the GA '-tts' ids.
     expect(speechTool.inputSchema.properties.model.enum).toEqual([
       'gemini-3.1-flash-tts-preview',
-      'gemini-2.5-flash-preview-tts',
-      'gemini-2.5-pro-preview-tts',
+      'gemini-2.5-flash-tts',
+      'gemini-2.5-pro-tts',
     ]);
     expect(speechTool.description).toContain('Input is text-only');
     expect(speechTool.inputSchema.properties.speakers.minItems).toBe(2);
@@ -259,6 +271,56 @@ describe('GeminiAIMCPServer generate_image wiring', () => {
     });
 
     expect(mockSpeechGenHandle).toHaveBeenCalledWith({ prompt: 'say hello', voiceName: 'Kore' });
+  });
+
+  it('advertises Google AI Studio TTS ids when Vertex mode is disabled', async () => {
+    const aiStudioServer = new GeminiAIMCPServer(createTestConfig({ useVertexAI: false }));
+    const handlers = getHandlers((aiStudioServer as any).server);
+    const result = await handlers.listHandler();
+    const speechTool = result.tools.find((t: any) => t.name === 'generate_speech');
+
+    expect(speechTool.inputSchema.properties.model.enum).toEqual([
+      'gemini-3.1-flash-tts-preview',
+      'gemini-2.5-flash-preview-tts',
+      'gemini-2.5-pro-preview-tts',
+    ]);
+
+    // A Vertex-only GA id must be rejected on the AI Studio backend.
+    const invalidResult = await handlers.callHandler({
+      params: {
+        name: 'generate_speech',
+        arguments: { prompt: 'hi', model: 'gemini-2.5-flash-tts' },
+      },
+    });
+    const errorBody = JSON.parse(invalidResult.content[0].text);
+    expect(invalidResult.isError).toBe(true);
+    expect(errorBody.errorType).toBe('validation_error');
+  });
+
+  it('generate_omni_video tool is exposed and routed to OmniVideoHandler', async () => {
+    const result = await listHandler();
+    const omniTool = result.tools.find((t: any) => t.name === 'generate_omni_video');
+
+    expect(omniTool).toBeDefined();
+    expect(omniTool.inputSchema.required).toContain('prompt');
+    expect(omniTool.inputSchema.properties.model.enum).toEqual(['gemini-omni-flash-preview']);
+    expect(omniTool.inputSchema.properties.aspectRatio.enum).toEqual(['16:9', '9:16']);
+    expect(omniTool.inputSchema.properties.durationSeconds.minimum).toBe(3);
+    expect(omniTool.inputSchema.properties.durationSeconds.maximum).toBe(10);
+    expect(omniTool.inputSchema.properties.imagePaths.maxItems).toBe(7);
+    expect(omniTool.inputSchema.properties.previousInteractionId).toBeDefined();
+    expect(omniTool.description).toContain('Omni Flash');
+    expect(omniTool.description).toContain('previousInteractionId');
+    expect(omniTool.description).toContain('720p');
+
+    await callHandler({
+      params: {
+        name: 'generate_omni_video',
+        arguments: { prompt: 'a fox running', durationSeconds: 6 },
+      },
+    });
+
+    expect(mockOmniVideoHandle).toHaveBeenCalledWith({ prompt: 'a fox running', durationSeconds: 6 });
   });
 
   it('generate_music tool is exposed and routed to MusicGenerationHandler', async () => {

--- a/src/server/GeminiAIMCPServer.test.ts
+++ b/src/server/GeminiAIMCPServer.test.ts
@@ -314,8 +314,9 @@ describe('GeminiAIMCPServer generate_image wiring', () => {
     expect(omniTool.inputSchema.required).toContain('prompt');
     expect(omniTool.inputSchema.properties.model.enum).toEqual(['gemini-omni-flash-preview']);
     expect(omniTool.inputSchema.properties.aspectRatio.enum).toEqual(['16:9', '9:16']);
-    expect(omniTool.inputSchema.properties.durationSeconds.minimum).toBe(3);
-    expect(omniTool.inputSchema.properties.durationSeconds.maximum).toBe(10);
+    // Omni Flash does not support a structured duration or system instruction.
+    expect(omniTool.inputSchema.properties.durationSeconds).toBeUndefined();
+    expect(omniTool.inputSchema.properties.systemInstruction).toBeUndefined();
     expect(omniTool.inputSchema.properties.imagePaths.maxItems).toBe(7);
     expect(omniTool.inputSchema.properties.previousInteractionId).toBeDefined();
     expect(omniTool.description).toContain('Omni Flash');
@@ -325,11 +326,11 @@ describe('GeminiAIMCPServer generate_image wiring', () => {
     await callHandler({
       params: {
         name: 'generate_omni_video',
-        arguments: { prompt: 'a fox running', durationSeconds: 6 },
+        arguments: { prompt: 'a fox running' },
       },
     });
 
-    expect(mockOmniVideoHandle).toHaveBeenCalledWith({ prompt: 'a fox running', durationSeconds: 6 });
+    expect(mockOmniVideoHandle).toHaveBeenCalledWith({ prompt: 'a fox running' });
   });
 
   it('generate_music tool is exposed and routed to MusicGenerationHandler', async () => {

--- a/src/server/GeminiAIMCPServer.ts
+++ b/src/server/GeminiAIMCPServer.ts
@@ -638,7 +638,7 @@ export class GeminiAIMCPServer {
             "AI-assisted reference search: answer a question from live web sources using Gemini's Google Search grounding, and return organized citations. " +
             "Unlike the OpenAI-spec 'search'/'fetch' connector tools, this composes a synthesized answer AND returns the source links plus claim->source supports (citations) in one call. " +
             "Returns: answer (synthesized text), citations (deduped {index,title,uri,domain} sources), supports (answer segments mapped to citation indices with confidence scores), searchQueries (the queries the model actually ran), and searchSuggestionsHtml (Google's required Search Suggestions markup to display alongside the answer). " +
-            "Search-scope tuning is backend-specific: Vertex AI supports excludeDomains (skip up to 2000 domains) and blockingConfidence (block risky/low-quality sites); Google AI Studio supports timeRange (restrict to a publish-time window). Both backends support includeImages and grounding on explicit urls via URL context.",
+            "Search-scope tuning is backend-specific: Vertex AI supports excludeDomains (skip up to 2000 domains) and blockingConfidence (block risky/low-quality sites); Google AI Studio supports timeRange (restrict to a publish-time window) and grounding on explicit urls via URL context (Gemini API only, not Vertex AI). Both backends support includeImages.",
           inputSchema: {
             type: "object",
             additionalProperties: false,
@@ -680,7 +680,7 @@ export class GeminiAIMCPServer {
                 type: "array",
                 items: { type: "string" },
                 maxItems: 20,
-                description: "Specific http(s) URLs to ground the answer on via URL context (max 20; both backends).",
+                description: "Specific http(s) URLs to ground the answer on via URL context (max 20). Google AI Studio backend only; the URL context tool is not available on Vertex AI.",
               },
               systemInstruction: {
                 type: "string",

--- a/src/server/GeminiAIMCPServer.ts
+++ b/src/server/GeminiAIMCPServer.ts
@@ -17,17 +17,20 @@ import {
   SearchSchema,
   FetchSchema,
   ImageGenerationSchema,
-  SpeechGenerationSchema,
+  buildSpeechGenerationSchema,
   CheckVideoSchema,
   buildMusicGenerationSchema,
   buildVideoGenerationSchema,
+  OmniVideoGenerationSchema,
   GEMINI_IMAGE_INPUT_FILE_TYPES,
   getAllowedVideoModels,
   getDefaultVideoModel,
+  getAllowedSpeechModels,
   getAllowedMusicOutputMimeTypes,
   ALLOWED_LYRIA_LANGUAGES,
   VEO_IMAGE_INPUT_FILE_TYPES,
   VEO_EXTENSION_VIDEO_FILE_TYPES,
+  OMNI_VIDEO_INPUT_FILE_TYPES,
 } from '../schemas/index.js';
 import { ConversationManager } from '../managers/ConversationManager.js';
 import { GeminiAIService } from '../services/GeminiAIService.js';
@@ -42,6 +45,7 @@ import { ImageGenerationHandler } from '../handlers/ImageGenerationHandler.js';
 import { SpeechGenerationHandler } from '../handlers/SpeechGenerationHandler.js';
 import { MusicGenerationHandler } from '../handlers/MusicGenerationHandler.js';
 import { VideoGenerationHandler } from '../handlers/VideoGenerationHandler.js';
+import { OmniVideoHandler } from '../handlers/OmniVideoHandler.js';
 import { getEffectiveSafeDirectories } from '../utils/fileSecurity.js';
 import { resolveOutputDirs } from '../utils/generatedFileSaver.js';
 
@@ -65,6 +69,7 @@ export class GeminiAIMCPServer {
   private speechGenerationHandler: SpeechGenerationHandler;
   private musicGenerationHandler: MusicGenerationHandler;
   private videoGenerationHandler: VideoGenerationHandler;
+  private omniVideoHandler: OmniVideoHandler;
 
   // Cache
   private searchCache: Map<string, CachedDocument>;
@@ -126,6 +131,7 @@ export class GeminiAIMCPServer {
     this.speechGenerationHandler = new SpeechGenerationHandler(this.geminiAI, config);
     this.musicGenerationHandler = new MusicGenerationHandler(this.geminiAI, config);
     this.videoGenerationHandler = new VideoGenerationHandler(this.geminiAI, config);
+    this.omniVideoHandler = new OmniVideoHandler(this.geminiAI, config);
 
     this.setupHandlers();
   }
@@ -149,6 +155,9 @@ export class GeminiAIMCPServer {
         : getAllowedVideoModels(this.config.useVertexAI);
       const defaultVideoModel = getDefaultVideoModel(this.config.useVertexAI);
       const maxVideoCount = dual ? 4 : (this.config.useVertexAI ? 4 : 1);
+      const speechModelEnum = dual
+        ? Array.from(new Set([...getAllowedSpeechModels(true), ...getAllowedSpeechModels(false)]))
+        : getAllowedSpeechModels(this.config.useVertexAI);
       const musicOutputMimeTypes = dual ? ['audio/mp3', 'audio/wav'] : getAllowedMusicOutputMimeTypes(this.config.useVertexAI);
       const musicOutputMimeDescription = dual
         ? "Optional output MIME type. Vertex AI supports audio/mp3 only; Google AI Studio supports audio/wav for lyria-3-pro-preview."
@@ -279,8 +288,10 @@ export class GeminiAIMCPServer {
           name: "generate_image",
           description:
             "Generate images using Gemini's native image generation (Nano Banana). " +
-            "Supports gemini-3-pro-image, gemini-3.1-flash-image, and gemini-2.5-flash-image models. " +
-            "gemini-2.5-flash-image supports at most 3 reference images and does not support imageSize; gemini-3.1-flash-image is required for 0.5K and 1:4/1:8/4:1/8:1 ratios. " +
+            "Supports gemini-3-pro-image, gemini-3.1-flash-image, gemini-3.1-flash-lite-image, and gemini-2.5-flash-image models. " +
+            "gemini-3.1-flash-lite-image (Nano Banana 2 Lite) is the fast, low-cost GA tier: 1K output only, standard aspect ratios (no 1:4/1:8/4:1/8:1), no thinkingLevel, up to 14 reference images. " +
+            "gemini-3.1-flash-image is required for 0.5K and 1:4/1:8/4:1/8:1 ratios. " +
+            "gemini-2.5-flash-image (legacy, retires 2026-10-02) supports at most 3 reference images and does not support imageSize. " +
             `Reference images use imagePaths and must be ${GEMINI_IMAGE_INPUT_FILE_TYPES}. ` +
             "Audio and video reference files are not accepted by generate_image. " +
             `Images are saved to ${this.imageGenerationHandler.getImageOutputDir()} and returned as base64.`,
@@ -294,8 +305,8 @@ export class GeminiAIMCPServer {
               },
               model: {
                 type: "string",
-                enum: ["gemini-3-pro-image", "gemini-3.1-flash-image", "gemini-2.5-flash-image"],
-                description: "Image model (default: gemini-3-pro-image; gemini-2.5-flash-image supports at most 3 reference images and does not support imageSize, and retires 2026-10-02 — prefer gemini-3.1-flash-image)",
+                enum: ["gemini-3-pro-image", "gemini-3.1-flash-image", "gemini-3.1-flash-lite-image", "gemini-2.5-flash-image"],
+                description: "Image model (default: gemini-3-pro-image). gemini-3.1-flash-lite-image = fast/low-cost GA tier (1K only, no thinkingLevel, no 1:4/1:8/4:1/8:1 ratios). gemini-2.5-flash-image = legacy (at most 3 reference images, no imageSize, retires 2026-10-02) — prefer gemini-3.1-flash-lite-image.",
               },
               aspectRatio: {
                 type: "string",
@@ -305,7 +316,7 @@ export class GeminiAIMCPServer {
               imageSize: {
                 type: "string",
                 enum: ["0.5K", "1K", "2K", "4K"],
-                description: "Resolution (0.5K requires gemini-3.1-flash-image, default: 1K)",
+                description: "Resolution (0.5K requires gemini-3.1-flash-image; gemini-3.1-flash-lite-image supports 1K only; default: 1K)",
               },
               imagePaths: {
                 type: "array",
@@ -348,8 +359,8 @@ export class GeminiAIMCPServer {
               },
               model: {
                 type: "string",
-                enum: ["gemini-3.1-flash-tts-preview", "gemini-2.5-flash-preview-tts", "gemini-2.5-pro-preview-tts"],
-                description: "Speech model (default: gemini-3.1-flash-tts-preview)",
+                enum: speechModelEnum,
+                description: "Speech model (default: gemini-3.1-flash-tts-preview, valid on both backends). Vertex AI uses GA ids gemini-2.5-flash-tts/gemini-2.5-pro-tts; Google AI Studio uses gemini-2.5-flash-preview-tts/gemini-2.5-pro-preview-tts.",
               },
               voiceName: {
                 type: "string",
@@ -575,6 +586,58 @@ export class GeminiAIMCPServer {
             required: ["operationId"],
           },
         },
+        {
+          name: "generate_omni_video",
+          description:
+            "Generate or conversationally edit short videos with Gemini Omni Flash (gemini-omni-flash-preview). " +
+            "This is a NON-Veo model on the Google AI Studio (Gemini API) backend and does NOT use generate_video/check_video: it returns the finished video synchronously in one call (no operationId polling). " +
+            "Two paths: (1) ONESHOT generation — text-to-video, or image/reference-to-video via imagePaths (max 7); " +
+            "(2) INTERACTIVE editing — set previousInteractionId to an id returned by a prior call to edit that video with a natural-language instruction (no image re-upload; chain up to 3 sequential edits). " +
+            "Constraints: 720p output only; aspect ratio 16:9 or 9:16; duration 3-10 seconds; a synced audio track is generated automatically (audio reference inputs are not accepted — describe dialogue/SFX/ambience in the prompt). " +
+            `Image source file types: ${OMNI_VIDEO_INPUT_FILE_TYPES}. ` +
+            `The response includes interactionId (pass it back as previousInteractionId to edit) and the saved file path. Videos are saved to ${this.omniVideoHandler.getVideoOutputDir()}.`,
+          inputSchema: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              prompt: {
+                type: "string",
+                description: "Video prompt for a new generation (oneshot), or a natural-language edit instruction when previousInteractionId is set (interactive editing). Describe dialogue/SFX/ambience as text; audio reference files are not accepted.",
+              },
+              model: {
+                type: "string",
+                enum: ["gemini-omni-flash-preview"],
+                description: "Omni video model (default: gemini-omni-flash-preview)",
+              },
+              aspectRatio: {
+                type: "string",
+                enum: ["16:9", "9:16"],
+                description: "Aspect ratio (default: 16:9). Omni Flash supports 16:9 and 9:16 only.",
+              },
+              durationSeconds: {
+                type: "number",
+                minimum: 3,
+                maximum: 10,
+                description: "Video duration in seconds (3-10; default: model default). Output is 720p only.",
+              },
+              imagePaths: {
+                type: "array",
+                items: { type: "string" },
+                maxItems: 7,
+                description: `Local file paths of source/reference images for image-to-video or reference-to-video (max 7). Supported file types: ${OMNI_VIDEO_INPUT_FILE_TYPES}. Omit for interactive edits — previousInteractionId reuses the prior video.`,
+              },
+              previousInteractionId: {
+                type: "string",
+                description: "Interaction ID from a prior generate_omni_video call. When set, conversationally edits that video (no image re-upload) instead of generating a new one.",
+              },
+              systemInstruction: {
+                type: "string",
+                description: "Optional system instruction to steer generation or editing",
+              },
+            },
+            required: ["prompt"],
+          },
+        },
       ];
 
       // When more than one backend is configured, advertise the per-request
@@ -586,6 +649,7 @@ export class GeminiAIMCPServer {
           "generate_speech",
           "generate_video",
           "generate_music",
+          "generate_omni_video",
         ]);
         for (const tool of tools) {
           if (backendTools.has(tool.name)) {
@@ -633,7 +697,7 @@ export class GeminiAIMCPServer {
           }
 
           case "generate_speech": {
-            const input = SpeechGenerationSchema.parse(args);
+            const input = buildSpeechGenerationSchema(this.config.useVertexAI, this.config.availableBackends).parse(args);
             return await this.speechGenerationHandler.handle(input);
           }
 
@@ -650,6 +714,11 @@ export class GeminiAIMCPServer {
           case "check_video": {
             const input = CheckVideoSchema.parse(args);
             return await this.videoGenerationHandler.handleCheck(input);
+          }
+
+          case "generate_omni_video": {
+            const input = OmniVideoGenerationSchema.parse(args);
+            return await this.omniVideoHandler.handle(input);
           }
 
           default:

--- a/src/server/GeminiAIMCPServer.ts
+++ b/src/server/GeminiAIMCPServer.ts
@@ -22,6 +22,7 @@ import {
   buildMusicGenerationSchema,
   buildVideoGenerationSchema,
   OmniVideoGenerationSchema,
+  buildReferenceSearchSchema,
   GEMINI_IMAGE_INPUT_FILE_TYPES,
   getAllowedVideoModels,
   getDefaultVideoModel,
@@ -46,6 +47,7 @@ import { SpeechGenerationHandler } from '../handlers/SpeechGenerationHandler.js'
 import { MusicGenerationHandler } from '../handlers/MusicGenerationHandler.js';
 import { VideoGenerationHandler } from '../handlers/VideoGenerationHandler.js';
 import { OmniVideoHandler } from '../handlers/OmniVideoHandler.js';
+import { ReferenceSearchHandler } from '../handlers/ReferenceSearchHandler.js';
 import { getEffectiveSafeDirectories } from '../utils/fileSecurity.js';
 import { resolveOutputDirs } from '../utils/generatedFileSaver.js';
 
@@ -70,6 +72,7 @@ export class GeminiAIMCPServer {
   private musicGenerationHandler: MusicGenerationHandler;
   private videoGenerationHandler: VideoGenerationHandler;
   private omniVideoHandler: OmniVideoHandler;
+  private referenceSearchHandler: ReferenceSearchHandler;
 
   // Cache
   private searchCache: Map<string, CachedDocument>;
@@ -132,6 +135,7 @@ export class GeminiAIMCPServer {
     this.musicGenerationHandler = new MusicGenerationHandler(this.geminiAI, config);
     this.videoGenerationHandler = new VideoGenerationHandler(this.geminiAI, config);
     this.omniVideoHandler = new OmniVideoHandler(this.geminiAI, config);
+    this.referenceSearchHandler = new ReferenceSearchHandler(this.geminiAI);
 
     this.setupHandlers();
   }
@@ -638,6 +642,69 @@ export class GeminiAIMCPServer {
             required: ["prompt"],
           },
         },
+        {
+          name: "reference_search",
+          description:
+            "AI-assisted reference search: answer a question from live web sources using Gemini's Google Search grounding, and return organized citations. " +
+            "Unlike the OpenAI-spec 'search'/'fetch' connector tools, this composes a synthesized answer AND returns the source links plus claim->source supports (citations) in one call. " +
+            "Returns: answer (synthesized text), citations (deduped {index,title,uri,domain} sources), supports (answer segments mapped to citation indices with confidence scores), searchQueries (the queries the model actually ran), and searchSuggestionsHtml (Google's required Search Suggestions markup to display alongside the answer). " +
+            "Search-scope tuning is backend-specific: Vertex AI supports excludeDomains (skip up to 2000 domains) and blockingConfidence (block risky/low-quality sites); Google AI Studio supports timeRange (restrict to a publish-time window). Both backends support includeImages and grounding on explicit urls via URL context.",
+          inputSchema: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              prompt: {
+                type: "string",
+                description: "Research question or topic to answer from live web sources.",
+              },
+              model: {
+                type: "string",
+                description: "Optional Gemini model override; must support Google Search grounding (default: server model).",
+              },
+              excludeDomains: {
+                type: "array",
+                items: { type: "string" },
+                maxItems: 2000,
+                description: "Domains to exclude from results, e.g. ['reddit.com','pinterest.com'] (search-scope tuning; max 2000). Vertex AI backend only.",
+              },
+              blockingConfidence: {
+                type: "string",
+                enum: ["low", "medium", "high"],
+                description: "Block risky/low-quality sites at or above this confidence ('low' is most aggressive). Vertex AI backend only.",
+              },
+              timeRange: {
+                type: "object",
+                additionalProperties: false,
+                properties: {
+                  startTime: { type: "string", description: "Inclusive RFC 3339 start timestamp, e.g. '2026-01-01T00:00:00Z'" },
+                  endTime: { type: "string", description: "Exclusive RFC 3339 end timestamp, e.g. '2026-07-01T00:00:00Z'" },
+                },
+                required: ["startTime", "endTime"],
+                description: "Restrict results to a publish-time window for recency tuning (both fields required). Google AI Studio backend only.",
+              },
+              includeImages: {
+                type: "boolean",
+                description: "Also enable image-search grounding in addition to web search.",
+              },
+              urls: {
+                type: "array",
+                items: { type: "string" },
+                maxItems: 20,
+                description: "Specific http(s) URLs to ground the answer on via URL context (max 20; both backends).",
+              },
+              systemInstruction: {
+                type: "string",
+                description: "Optional system instruction to steer the tone, depth, or scope of the composed answer.",
+              },
+              thinkingLevel: {
+                type: "string",
+                enum: ["minimal", "low", "medium", "high"],
+                description: "Optional Gemini 3 thinking level override for the reasoning depth of the answer.",
+              },
+            },
+            required: ["prompt"],
+          },
+        },
       ];
 
       // When more than one backend is configured, advertise the per-request
@@ -650,6 +717,7 @@ export class GeminiAIMCPServer {
           "generate_video",
           "generate_music",
           "generate_omni_video",
+          "reference_search",
         ]);
         for (const tool of tools) {
           if (backendTools.has(tool.name)) {
@@ -719,6 +787,11 @@ export class GeminiAIMCPServer {
           case "generate_omni_video": {
             const input = OmniVideoGenerationSchema.parse(args);
             return await this.omniVideoHandler.handle(input);
+          }
+
+          case "reference_search": {
+            const input = buildReferenceSearchSchema(this.config.useVertexAI, this.config.availableBackends).parse(args);
+            return await this.referenceSearchHandler.handle(input);
           }
 
           default:

--- a/src/server/GeminiAIMCPServer.ts
+++ b/src/server/GeminiAIMCPServer.ts
@@ -597,7 +597,7 @@ export class GeminiAIMCPServer {
             "This is a NON-Veo model on the Google AI Studio (Gemini API) backend and does NOT use generate_video/check_video: it returns the finished video synchronously in one call (no operationId polling). " +
             "Two paths: (1) ONESHOT generation — text-to-video, or image/reference-to-video via imagePaths (max 7); " +
             "(2) INTERACTIVE editing — set previousInteractionId to an id returned by a prior call to edit that video with a natural-language instruction (no image re-upload; chain up to 3 sequential edits). " +
-            "Constraints: 720p output only; aspect ratio 16:9 or 9:16; duration 3-10 seconds; a synced audio track is generated automatically (audio reference inputs are not accepted — describe dialogue/SFX/ambience in the prompt). " +
+            "Constraints: 720p output only; aspect ratio 16:9 or 9:16; clips run a few seconds (steer pacing/timing within the prompt — duration is not a parameter); a synced audio track is generated automatically (audio reference inputs are not accepted — describe dialogue/SFX/ambience in the prompt). " +
             `Image source file types: ${OMNI_VIDEO_INPUT_FILE_TYPES}. ` +
             `The response includes interactionId (pass it back as previousInteractionId to edit) and the saved file path. Videos are saved to ${this.omniVideoHandler.getVideoOutputDir()}.`,
           inputSchema: {
@@ -616,13 +616,7 @@ export class GeminiAIMCPServer {
               aspectRatio: {
                 type: "string",
                 enum: ["16:9", "9:16"],
-                description: "Aspect ratio (default: 16:9). Omni Flash supports 16:9 and 9:16 only.",
-              },
-              durationSeconds: {
-                type: "number",
-                minimum: 3,
-                maximum: 10,
-                description: "Video duration in seconds (3-10; default: model default). Output is 720p only.",
+                description: "Aspect ratio (default: 16:9). Omni Flash supports 16:9 and 9:16 only. Output is 720p only.",
               },
               imagePaths: {
                 type: "array",
@@ -633,10 +627,6 @@ export class GeminiAIMCPServer {
               previousInteractionId: {
                 type: "string",
                 description: "Interaction ID from a prior generate_omni_video call. When set, conversationally edits that video (no image re-upload) instead of generating a new one.",
-              },
-              systemInstruction: {
-                type: "string",
-                description: "Optional system instruction to steer generation or editing",
               },
             },
             required: ["prompt"],

--- a/src/services/GeminiAIService.test.ts
+++ b/src/services/GeminiAIService.test.ts
@@ -416,13 +416,14 @@ describe('generateOmniVideo (Interactions API)', () => {
 
   function stubInteractions(service: GeminiAIService, interaction: Record<string, unknown>) {
     const create = vi.fn().mockResolvedValue(interaction);
-    (service as any).clientFor = () => ({ interactions: { create } });
-    return create;
+    const clientFor = vi.fn(() => ({ interactions: { create } }));
+    (service as any).clientFor = clientFor;
+    return { create, clientFor };
   }
 
   it('oneshot text-to-video builds a video response_format and returns the interactionId', async () => {
     const service = new GeminiAIService(createServiceConfig());
-    const create = stubInteractions(service, {
+    const { create } = stubInteractions(service, {
       id: 'omni-1',
       status: 'completed',
       output_video: { data: Buffer.from('fake-mp4').toString('base64'), mime_type: 'video/mp4' },
@@ -431,15 +432,17 @@ describe('generateOmniVideo (Interactions API)', () => {
 
     const result = await service.generateOmniVideo('a fox running through snow', {
       aspectRatio: '9:16',
-      durationSeconds: 8,
     });
 
     const params = create.mock.calls[0][0];
     expect(params.model).toBe('gemini-omni-flash-preview');
     expect(params.input).toBe('a fox running through snow');
-    expect(params.response_format).toEqual({ type: 'video', aspect_ratio: '9:16', duration: '8' });
+    // Omni Flash does not support a structured duration field on response_format.
+    expect(params.response_format).toEqual({ type: 'video', aspect_ratio: '9:16' });
     expect(params.store).toBe(true);
     expect(params).not.toHaveProperty('previous_interaction_id');
+    // system_instruction is not supported by Omni Flash and must not be forwarded.
+    expect(params).not.toHaveProperty('system_instruction');
 
     expect(result.interactionId).toBe('omni-1');
     expect(result.video.mimeType).toBe('video/mp4');
@@ -447,9 +450,38 @@ describe('generateOmniVideo (Interactions API)', () => {
     expect(result.text).toBe('here is your clip');
   });
 
+  it('defaults to the Google AI Studio backend even when the server default is Vertex', async () => {
+    const service = new GeminiAIService(
+      createServiceConfig({ useVertexAI: true, defaultBackend: 'vertex', availableBackends: ['vertex', 'ai-studio'] })
+    );
+    const { clientFor } = stubInteractions(service, {
+      id: 'omni-vx',
+      status: 'completed',
+      output_video: { data: Buffer.from('clip').toString('base64'), mime_type: 'video/mp4' },
+    });
+
+    await service.generateOmniVideo('a kite in the wind');
+
+    // Omni is AI-Studio-only; it must not route to Vertex despite the server default.
+    expect(clientFor).toHaveBeenCalledWith('ai-studio');
+  });
+
+  it('honors an explicit backend override', async () => {
+    const service = new GeminiAIService(createServiceConfig());
+    const { clientFor } = stubInteractions(service, {
+      id: 'omni-ov',
+      status: 'completed',
+      output_video: { data: Buffer.from('clip').toString('base64'), mime_type: 'video/mp4' },
+    });
+
+    await service.generateOmniVideo('a kite in the wind', { backend: 'vertex' });
+
+    expect(clientFor).toHaveBeenCalledWith('vertex');
+  });
+
   it('interactive edit forwards previousInteractionId as previous_interaction_id', async () => {
     const service = new GeminiAIService(createServiceConfig());
-    const create = stubInteractions(service, {
+    const { create } = stubInteractions(service, {
       id: 'omni-2',
       status: 'completed',
       output_video: { data: Buffer.from('edited').toString('base64'), mime_type: 'video/mp4' },

--- a/src/services/GeminiAIService.test.ts
+++ b/src/services/GeminiAIService.test.ts
@@ -388,6 +388,91 @@ describe('generateVideo backend compatibility', () => {
   });
 });
 
+describe('generateOmniVideo (Interactions API)', () => {
+  function createServiceConfig(overrides: Record<string, unknown> = {}) {
+    return {
+      projectId: 'test-project',
+      location: 'us-central1',
+      apiKey: 'test-api-key',
+      useVertexAI: false,
+      defaultBackend: 'ai-studio',
+      availableBackends: ['ai-studio'],
+      model: 'gemini-3.5-flash',
+      temperature: 0.7,
+      maxTokens: 8192,
+      topP: 0.95,
+      topK: 40,
+      enableConversations: false,
+      sessionTimeout: 3600000,
+      maxHistory: 100,
+      enableReasoning: false,
+      maxReasoningSteps: 5,
+      disableLogging: true,
+      logToStderr: false,
+      allowFileUris: false,
+      ...overrides,
+    } as any;
+  }
+
+  function stubInteractions(service: GeminiAIService, interaction: Record<string, unknown>) {
+    const create = vi.fn().mockResolvedValue(interaction);
+    (service as any).clientFor = () => ({ interactions: { create } });
+    return create;
+  }
+
+  it('oneshot text-to-video builds a video response_format and returns the interactionId', async () => {
+    const service = new GeminiAIService(createServiceConfig());
+    const create = stubInteractions(service, {
+      id: 'omni-1',
+      status: 'completed',
+      output_video: { data: Buffer.from('fake-mp4').toString('base64'), mime_type: 'video/mp4' },
+      output_text: 'here is your clip',
+    });
+
+    const result = await service.generateOmniVideo('a fox running through snow', {
+      aspectRatio: '9:16',
+      durationSeconds: 8,
+    });
+
+    const params = create.mock.calls[0][0];
+    expect(params.model).toBe('gemini-omni-flash-preview');
+    expect(params.input).toBe('a fox running through snow');
+    expect(params.response_format).toEqual({ type: 'video', aspect_ratio: '9:16', duration: '8' });
+    expect(params.store).toBe(true);
+    expect(params).not.toHaveProperty('previous_interaction_id');
+
+    expect(result.interactionId).toBe('omni-1');
+    expect(result.video.mimeType).toBe('video/mp4');
+    expect(result.video.data.toString()).toBe('fake-mp4');
+    expect(result.text).toBe('here is your clip');
+  });
+
+  it('interactive edit forwards previousInteractionId as previous_interaction_id', async () => {
+    const service = new GeminiAIService(createServiceConfig());
+    const create = stubInteractions(service, {
+      id: 'omni-2',
+      status: 'completed',
+      output_video: { data: Buffer.from('edited').toString('base64'), mime_type: 'video/mp4' },
+    });
+
+    const result = await service.generateOmniVideo('make the sky orange', {
+      previousInteractionId: 'omni-1',
+    });
+
+    const params = create.mock.calls[0][0];
+    expect(params.previous_interaction_id).toBe('omni-1');
+    expect(params.input).toBe('make the sky orange');
+    expect(result.interactionId).toBe('omni-2');
+  });
+
+  it('throws a descriptive error when no video is returned', async () => {
+    const service = new GeminiAIService(createServiceConfig());
+    stubInteractions(service, { id: 'omni-3', status: 'failed', output_text: 'blocked' });
+
+    await expect(service.generateOmniVideo('x')).rejects.toThrow(/no video \(status: failed\): blocked/);
+  });
+});
+
 describe('QueryOptions interface', () => {
   it('accepts mediaResolution option', async () => {
     const { ThinkingLevel } = await import('@google/genai');

--- a/src/services/GeminiAIService.test.ts
+++ b/src/services/GeminiAIService.test.ts
@@ -473,6 +473,142 @@ describe('generateOmniVideo (Interactions API)', () => {
   });
 });
 
+describe('referenceSearch (Google Search grounding)', () => {
+  function createServiceConfig(overrides: Record<string, unknown> = {}) {
+    return {
+      projectId: 'test-project',
+      location: 'us-central1',
+      apiKey: 'test-api-key',
+      useVertexAI: true,
+      model: 'gemini-3.5-flash',
+      temperature: 0.7,
+      maxTokens: 8192,
+      topP: 0.95,
+      topK: 40,
+      enableConversations: false,
+      sessionTimeout: 3600000,
+      maxHistory: 100,
+      enableReasoning: false,
+      maxReasoningSteps: 5,
+      disableLogging: true,
+      logToStderr: false,
+      allowFileUris: false,
+      ...overrides,
+    } as any;
+  }
+
+  function stubGenerateContent(service: GeminiAIService, response: Record<string, unknown>) {
+    const generateContent = vi.fn().mockResolvedValue(response);
+    (service as any).clientFor = () => ({ models: { generateContent } });
+    return generateContent;
+  }
+
+  const groundedResponse = {
+    candidates: [{
+      content: { parts: [{ text: 'Gemini 3 launched in 2026.' }] },
+      groundingMetadata: {
+        webSearchQueries: ['gemini 3 launch date'],
+        groundingChunks: [
+          { web: { uri: 'https://blog.google/gemini', title: 'Gemini blog', domain: 'blog.google' } },
+          { web: { uri: 'https://ai.google.dev', title: 'AI docs', domain: 'ai.google.dev' } },
+          { retrievedContext: {} }, // no web -> filtered out
+        ],
+        groundingSupports: [
+          {
+            segment: { startIndex: 0, endIndex: 9, text: 'Gemini 3' },
+            groundingChunkIndices: [0, 1],
+            confidenceScores: [0.98, 0.71],
+          },
+        ],
+        searchEntryPoint: { renderedContent: '<div>Search Suggestions</div>' },
+      },
+    }],
+  };
+
+  it('sends Vertex-only excludeDomains/blockingConfidence and maps grounding metadata', async () => {
+    const service = new GeminiAIService(createServiceConfig());
+    const generateContent = stubGenerateContent(service, groundedResponse);
+
+    const result = await service.referenceSearch('when did Gemini 3 launch?', {
+      excludeDomains: ['reddit.com'],
+      blockingConfidence: 'medium',
+      includeImages: true,
+    });
+
+    const params = generateContent.mock.calls[0][0];
+    const googleSearch = params.config.tools[0].googleSearch;
+    expect(googleSearch.excludeDomains).toEqual(['reddit.com']);
+    expect(googleSearch.blockingConfidence).toBe('BLOCK_MEDIUM_AND_ABOVE');
+    expect(googleSearch.searchTypes).toEqual({ webSearch: {}, imageSearch: {} });
+    expect(googleSearch).not.toHaveProperty('timeRangeFilter');
+    expect(params.config.tools).toHaveLength(1); // no urlContext without urls
+
+    expect(result.text).toBe('Gemini 3 launched in 2026.');
+    expect(result.searchQueries).toEqual(['gemini 3 launch date']);
+    // third chunk (no web) is filtered out
+    expect(result.citations).toEqual([
+      { index: 0, title: 'Gemini blog', uri: 'https://blog.google/gemini', domain: 'blog.google' },
+      { index: 1, title: 'AI docs', uri: 'https://ai.google.dev', domain: 'ai.google.dev' },
+    ]);
+    expect(result.supports[0].sourceIndices).toEqual([0, 1]);
+    expect(result.supports[0].confidenceScores).toEqual([0.98, 0.71]);
+    expect(result.searchEntryPoint).toBe('<div>Search Suggestions</div>');
+  });
+
+  it('sends timeRangeFilter and a urlContext tool on the Google AI Studio backend', async () => {
+    const service = new GeminiAIService(createServiceConfig({
+      useVertexAI: false,
+      projectId: undefined,
+      defaultBackend: 'ai-studio',
+      availableBackends: ['ai-studio'],
+    }));
+    const generateContent = stubGenerateContent(service, groundedResponse);
+
+    await service.referenceSearch('recent AI news', {
+      timeRange: { startTime: '2026-06-01T00:00:00Z', endTime: '2026-07-01T00:00:00Z' },
+      urls: ['https://ai.google.dev/docs'],
+    });
+
+    const params = generateContent.mock.calls[0][0];
+    const googleSearch = params.config.tools[0].googleSearch;
+    expect(googleSearch.timeRangeFilter).toEqual({
+      startTime: '2026-06-01T00:00:00Z',
+      endTime: '2026-07-01T00:00:00Z',
+    });
+    expect(params.config.tools[1]).toEqual({ urlContext: {} });
+    // explicit urls are appended to the request text so URL context fetches them
+    expect(params.contents).toContain('https://ai.google.dev/docs');
+    expect(params.contents).toContain('recent AI news');
+  });
+
+  it('falls back to byte-slicing the answer when a support segment omits text', async () => {
+    const service = new GeminiAIService(createServiceConfig());
+    stubGenerateContent(service, {
+      candidates: [{
+        content: { parts: [{ text: 'Hello world answer' }] },
+        groundingMetadata: {
+          groundingSupports: [
+            { segment: { startIndex: 0, endIndex: 5 }, groundingChunkIndices: [0] },
+          ],
+        },
+      }],
+    });
+
+    const result = await service.referenceSearch('x');
+    expect(result.supports[0].text).toBe('Hello');
+    expect(result.citations).toEqual([]);
+    expect(result.searchQueries).toEqual([]);
+  });
+
+  it('rejects an invalid blockingConfidence value', async () => {
+    const service = new GeminiAIService(createServiceConfig());
+    stubGenerateContent(service, groundedResponse);
+
+    await expect(service.referenceSearch('x', { blockingConfidence: 'extreme' }))
+      .rejects.toThrow(/Invalid blockingConfidence/);
+  });
+});
+
 describe('QueryOptions interface', () => {
   it('accepts mediaResolution option', async () => {
     const { ThinkingLevel } = await import('@google/genai');

--- a/src/services/GeminiAIService.ts
+++ b/src/services/GeminiAIService.ts
@@ -57,6 +57,22 @@ export interface GeneratedVideo {
   mimeType: string;
 }
 
+export interface OmniVideoGenerationOptions {
+  model?: string;
+  aspectRatio?: string;
+  durationSeconds?: number;
+  imagePaths?: string[];
+  previousInteractionId?: string;
+  systemInstruction?: string;
+  backend?: Backend;
+}
+
+export interface GeneratedOmniVideo {
+  interactionId: string;
+  video: GeneratedVideo;
+  text?: string;
+}
+
 export interface SpeechSpeakerOptions {
   speaker: string;
   voiceName: string;
@@ -842,6 +858,84 @@ export class GeminiAIService {
     }
 
     return { done: true, videos };
+  }
+
+  /**
+   * Generate or conversationally edit a video with Gemini Omni Flash.
+   *
+   * Unlike Veo (generateVideo), Omni Flash uses the Interactions API
+   * (client.interactions.create) and returns the finished video synchronously —
+   * there is no long-running operation to poll via check_video. The returned
+   * interactionId can be passed back as previousInteractionId to edit the result
+   * without re-uploading any source media.
+   */
+  async generateOmniVideo(
+    prompt: string,
+    options: OmniVideoGenerationOptions = {}
+  ): Promise<GeneratedOmniVideo> {
+    const backend = this.resolveBackend(options.backend);
+    const client = this.clientFor(backend);
+    const model = options.model || 'gemini-omni-flash-preview';
+
+    // Video output format: aspect ratio and duration live on response_format.
+    const responseFormat: any = { type: 'video' };
+    if (options.aspectRatio) {
+      responseFormat.aspect_ratio = options.aspectRatio;
+    }
+    if (options.durationSeconds !== undefined) {
+      responseFormat.duration = String(options.durationSeconds);
+    }
+
+    // Input is a plain string for text-to-video / interactive edits, or text plus
+    // inline reference images for image-to-video / reference-to-video.
+    let input: any = prompt;
+    if (options.imagePaths && options.imagePaths.length > 0) {
+      input = [
+        { type: 'text', text: prompt },
+        ...options.imagePaths.map((filePath) => ({
+          type: 'image',
+          data: readFileSync(filePath).toString('base64'),
+          mime_type: this.getMimeTypeFromExtension(extname(filePath)),
+        })),
+      ];
+    }
+
+    const params: any = {
+      model,
+      input,
+      response_format: responseFormat,
+      // Persist the interaction so a later edit can reference it by id.
+      store: true,
+    };
+    if (options.previousInteractionId) {
+      params.previous_interaction_id = options.previousInteractionId;
+    }
+    if (options.systemInstruction) {
+      params.system_instruction = options.systemInstruction;
+    }
+
+    const interaction: any = await client.interactions.create(params);
+
+    const outputVideo = interaction?.output_video;
+    if (!outputVideo || (!outputVideo.data && !outputVideo.uri)) {
+      const status = interaction?.status ?? 'unknown';
+      const detail = interaction?.output_text ? `: ${interaction.output_text}` : '';
+      throw new Error(`Omni video generation returned no video (status: ${status})${detail}`);
+    }
+
+    let data: Buffer;
+    if (outputVideo.data) {
+      data = Buffer.from(outputVideo.data, 'base64');
+    } else {
+      const resp = await fetch(outputVideo.uri);
+      data = Buffer.from(await resp.arrayBuffer());
+    }
+
+    return {
+      interactionId: interaction.id,
+      video: { data, mimeType: outputVideo.mime_type || 'video/mp4' },
+      text: interaction.output_text,
+    };
   }
 
   /**

--- a/src/services/GeminiAIService.ts
+++ b/src/services/GeminiAIService.ts
@@ -73,6 +73,41 @@ export interface GeneratedOmniVideo {
   text?: string;
 }
 
+export interface ReferenceSearchOptions {
+  model?: string;
+  backend?: Backend;
+  excludeDomains?: string[];
+  blockingConfidence?: string;   // 'low' | 'medium' | 'high'
+  timeRange?: { startTime: string; endTime: string };
+  includeImages?: boolean;
+  urls?: string[];
+  systemInstruction?: string;
+  thinkingLevel?: ThinkingLevel | string;
+}
+
+export interface ReferenceCitation {
+  index: number;
+  title?: string;
+  uri?: string;
+  domain?: string;
+}
+
+export interface ReferenceSupport {
+  text: string;
+  startIndex?: number;
+  endIndex?: number;
+  sourceIndices: number[];
+  confidenceScores?: number[];
+}
+
+export interface ReferenceSearchResult {
+  text: string;
+  citations: ReferenceCitation[];
+  supports: ReferenceSupport[];
+  searchQueries: string[];
+  searchEntryPoint?: string;
+}
+
 export interface SpeechSpeakerOptions {
   speaker: string;
   voiceName: string;
@@ -935,6 +970,130 @@ export class GeminiAIService {
       interactionId: interaction.id,
       video: { data, mimeType: outputVideo.mime_type || 'video/mp4' },
       text: interaction.output_text,
+    };
+  }
+
+  private resolveBlockingConfidence(level?: string): string | undefined {
+    if (!level) {
+      return undefined;
+    }
+    switch (level.trim().toLowerCase()) {
+      case 'low':
+        return 'BLOCK_LOW_AND_ABOVE';
+      case 'medium':
+        return 'BLOCK_MEDIUM_AND_ABOVE';
+      case 'high':
+        return 'BLOCK_HIGH_AND_ABOVE';
+      default:
+        throw new Error(
+          `Invalid blockingConfidence: ${level}. Expected one of low, medium, high.`
+        );
+    }
+  }
+
+  /**
+   * AI-assisted reference search: compose an answer from live web sources using
+   * Gemini's Google Search grounding and return organized citations.
+   *
+   * Search-scope tuning is backend-asymmetric per the @google/genai GoogleSearch
+   * tool: excludeDomains/blockingConfidence are Vertex AI only, timeRange
+   * (timeRangeFilter) is Google AI Studio only. When urls are supplied the URL
+   * context tool is added so the model also grounds on those specific pages.
+   */
+  async referenceSearch(
+    prompt: string,
+    options: ReferenceSearchOptions = {}
+  ): Promise<ReferenceSearchResult> {
+    const backend = this.resolveBackend(options.backend);
+    const client = this.clientFor(backend);
+    const model = options.model || this.config.model;
+
+    const googleSearch: any = {};
+    if (options.excludeDomains && options.excludeDomains.length > 0) {
+      googleSearch.excludeDomains = options.excludeDomains;
+    }
+    if (options.blockingConfidence) {
+      googleSearch.blockingConfidence = this.resolveBlockingConfidence(options.blockingConfidence);
+    }
+    if (options.timeRange) {
+      googleSearch.timeRangeFilter = {
+        startTime: options.timeRange.startTime,
+        endTime: options.timeRange.endTime,
+      };
+    }
+    if (options.includeImages) {
+      googleSearch.searchTypes = { webSearch: {}, imageSearch: {} };
+    }
+
+    const tools: any[] = [{ googleSearch }];
+    if (options.urls && options.urls.length > 0) {
+      tools.push({ urlContext: {} });
+    }
+
+    const config: GenerateContentConfig = {
+      temperature: this.config.temperature,
+      maxOutputTokens: this.config.maxTokens,
+      tools,
+    };
+    if (options.systemInstruction) {
+      config.systemInstruction = options.systemInstruction;
+    }
+    if (this.isGemini3Model(model)) {
+      config.thinkingConfig = {
+        thinkingLevel: this.resolveThinkingLevel(options.thinkingLevel) ?? ThinkingLevel.HIGH,
+      };
+    }
+
+    // URL context is driven by URLs present in the prompt, so append any
+    // explicit urls to the request text for the model to fetch.
+    const contents = options.urls && options.urls.length > 0
+      ? `${prompt}\n\nGround your answer using these sources:\n${options.urls.join('\n')}`
+      : prompt;
+
+    const response: any = await client.models.generateContent({ model, contents, config });
+    return this.extractReferenceResult(response);
+  }
+
+  private extractReferenceResult(response: any): ReferenceSearchResult {
+    const text = this.extractResponseText(response);
+    const grounding = response?.candidates?.[0]?.groundingMetadata ?? {};
+
+    const chunks: any[] = grounding.groundingChunks ?? [];
+    const citations: ReferenceCitation[] = chunks
+      .map((chunk, index) => ({
+        index,
+        title: chunk?.web?.title,
+        uri: chunk?.web?.uri,
+        domain: chunk?.web?.domain,
+      }))
+      .filter((citation) => citation.uri || citation.title);
+
+    const answerBytes = Buffer.from(text, 'utf-8');
+    const supports: ReferenceSupport[] = (grounding.groundingSupports ?? []).map((support: any) => {
+      const segment = support?.segment ?? {};
+      let segmentText: string | undefined = segment.text;
+      // Grounding segment indices are byte offsets into the answer; slice as a
+      // fallback when the API omits the resolved text.
+      if (segmentText === undefined && (segment.startIndex !== undefined || segment.endIndex !== undefined)) {
+        const start = segment.startIndex ?? 0;
+        const end = segment.endIndex ?? answerBytes.length;
+        segmentText = answerBytes.subarray(start, end).toString('utf-8');
+      }
+      return {
+        text: segmentText ?? '',
+        startIndex: segment.startIndex,
+        endIndex: segment.endIndex,
+        sourceIndices: support?.groundingChunkIndices ?? [],
+        confidenceScores: support?.confidenceScores,
+      };
+    });
+
+    return {
+      text,
+      citations,
+      supports,
+      searchQueries: grounding.webSearchQueries ?? [],
+      searchEntryPoint: grounding.searchEntryPoint?.renderedContent,
     };
   }
 

--- a/src/services/GeminiAIService.ts
+++ b/src/services/GeminiAIService.ts
@@ -60,10 +60,8 @@ export interface GeneratedVideo {
 export interface OmniVideoGenerationOptions {
   model?: string;
   aspectRatio?: string;
-  durationSeconds?: number;
   imagePaths?: string[];
   previousInteractionId?: string;
-  systemInstruction?: string;
   backend?: Backend;
 }
 
@@ -908,17 +906,20 @@ export class GeminiAIService {
     prompt: string,
     options: OmniVideoGenerationOptions = {}
   ): Promise<GeneratedOmniVideo> {
-    const backend = this.resolveBackend(options.backend);
+    // Omni Flash (gemini-omni-flash-preview) is served on Google AI Studio
+    // (Gemini API) only; it is not available on Vertex AI yet. Default to
+    // ai-studio rather than the server default backend so a Vertex-default setup
+    // still reaches Omni; an explicit backend override is honored for when Vertex
+    // availability rolls out.
+    const backend = options.backend ?? 'ai-studio';
     const client = this.clientFor(backend);
     const model = options.model || 'gemini-omni-flash-preview';
 
-    // Video output format: aspect ratio and duration live on response_format.
+    // Video output format. Omni Flash documents only type and aspect_ratio here;
+    // duration is not a structured field (steer clip timing within the prompt).
     const responseFormat: any = { type: 'video' };
     if (options.aspectRatio) {
       responseFormat.aspect_ratio = options.aspectRatio;
-    }
-    if (options.durationSeconds !== undefined) {
-      responseFormat.duration = String(options.durationSeconds);
     }
 
     // Input is a plain string for text-to-video / interactive edits, or text plus
@@ -944,9 +945,6 @@ export class GeminiAIService {
     };
     if (options.previousInteractionId) {
       params.previous_interaction_id = options.previousInteractionId;
-    }
-    if (options.systemInstruction) {
-      params.system_instruction = options.systemInstruction;
     }
 
     const interaction: any = await client.interactions.create(params);

--- a/src/services/GeminiAIService.ts
+++ b/src/services/GeminiAIService.ts
@@ -995,8 +995,9 @@ export class GeminiAIService {
    *
    * Search-scope tuning is backend-asymmetric per the @google/genai GoogleSearch
    * tool: excludeDomains/blockingConfidence are Vertex AI only, timeRange
-   * (timeRangeFilter) is Google AI Studio only. When urls are supplied the URL
-   * context tool is added so the model also grounds on those specific pages.
+   * (timeRangeFilter) and urls (URL context) are Google AI Studio only. When urls
+   * are supplied the URL context tool is added so the model also grounds on those
+   * specific pages; the schema rejects urls on Vertex before reaching this call.
    */
   async referenceSearch(
     prompt: string,


### PR DESCRIPTION
## Summary

Implements the models announced in the Gemini Omni Flash / Nano Banana 2 Lite post and bumps the SDKs.

- **SDK**: `@google/genai ^2.8.0 → ^2.10.0` (Interactions API), `@modelcontextprotocol/sdk ^1.26.0 → ^1.29.0`.
- **Image — Nano Banana 2 Lite** (`gemini-3.1-flash-lite-image`): added to the image model enum, 1K-only (a refine rejects any other `imageSize`). The existing flash-image-only aspect-ratio / `0.5K` / `thinkingLevel` refines already gate it out of unsupported options. `gemini-2.5-flash-image` is kept (retires 2026-10-02).
- **Speech — per-backend TTS ids**: Vertex AI GA (`gemini-2.5-flash-tts` / `gemini-2.5-pro-tts`) vs Google AI Studio preview (`gemini-2.5-flash-preview-tts` / `gemini-2.5-pro-preview-tts`); `gemini-3.1-flash-tts-preview` valid on both. `buildSpeechGenerationSchema` resolves the enum per request and a model↔backend match refine rejects a mismatched id.
- **New tool — `generate_omni_video`** (Gemini Omni Flash, `gemini-omni-flash-preview`): NON-Veo. Uses the Interactions API and returns the finished video synchronously (no `operationId` polling). Two paths — oneshot (text / image / reference-to-video) and interactive editing via `previousInteractionId` (chain up to 3 edits). 720p only, 16:9 / 9:16, 3-10s, audio auto-generated. Constraints are stated in the tool and parameter descriptions so MCP clients can self-restrict.
- **Docs**: README, GENERATION, ARCHITECTURE, examples, `.env.example`, and an ADR.

## Verification

- `npm run build` → exit 0
- `vitest run` → **100/100 tests pass** (8 files; +15 new)
- Runtime `tools/list` confirms `generate_omni_video` (7 params), the image enum incl. Lite, and the per-backend speech enum.

## Notes

- Omni Flash runs on the Google AI Studio backend; Vertex AI availability is rolling out (noted in the tool description).
- SDK usage validated against the real `@google/genai` 2.10.0 type surface (`interactions.create` / `VideoContent` / `VideoResponseFormat` / `InteractionsInput`).
