### PR TITLE
feat: update Gemini Flash models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,9 @@ GOOGLE_CLOUD_LOCATION=global
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-key.json
 
 # Model Configuration
-GEMINI_MODEL=gemini-3.5-flash
+GEMINI_MODEL=gemini-3.6-flash
+# Sampling overrides apply only to older models; Gemini 3.6 Flash and
+# Gemini 3.5 Flash-Lite use their model defaults.
 GEMINI_TEMPERATURE=1.0
 GEMINI_MAX_TOKENS=8192
 GEMINI_TOP_P=0.95

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -677,7 +677,7 @@ Validates the `query` tool input:
 z.object({
   prompt: z.string(),
   sessionId: z.string().optional(),
-  model: z.string().optional(),  // e.g., 'gemini-3.5-flash', 'gemini-3.1-pro-preview', 'gemini-3.1-flash-lite'
+  model: z.string().optional(),  // e.g., 'gemini-3.6-flash', 'gemini-3.5-flash-lite', 'gemini-3.1-pro-preview'
   thinkingLevel: z.enum(['minimal','low','medium','high']).optional(),
   mediaResolution: z.enum(['low','medium','high']).optional(),
   parts: z.array(MultimodalPartSchema).optional(),
@@ -970,7 +970,7 @@ Each runs as separate process with independent:
 - `errors/` folder (SecurityError, ModelBehaviorError)
 - `utils/` folder (Logger, generated file savers, security validators)
 - `handlers/` folder (QueryHandler, SearchHandler, FetchHandler, generation handlers)
-- Gemini 3 model support (`gemini-3.5-flash` default, `thinkingLevel` API)
+- Gemini 3 model support (`gemini-3.6-flash` default, `thinkingLevel` API)
 - File-output generation tools (`generate_image`, `generate_video`, `check_video`, `generate_omni_video`, `generate_speech`, `generate_music`)
 
 **Benefits**:

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -88,7 +88,7 @@ The Gemini AI MCP Server is a production-grade intelligent agent that enables AI
 - Speech generation via Gemini TTS models (`generateSpeech`)
 - Music generation via Lyria models (`generateMusic`)
 - Video generation via Veo models (`generateVideo`, `checkVideoOperation`)
-- Supports Gemini 3 models (`gemini-3.5-flash`, `gemini-3.1-pro-preview`, and later)
+- Supports Gemini 3 models (`gemini-3.6-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-pro-preview`, and later)
 
 **Logger.ts** (`src/utils/`)
 - File-based logging (`logs/general.log`, `logs/reasoning.log`)
@@ -220,7 +220,7 @@ User Input → Turn 1..10 Loop:
 - Returns saved file paths
 
 ### 11. Gemini 3 Model Support
-- Full support for `gemini-3.5-flash`, `gemini-3.1-pro-preview`, and subsequent Gemini 3 models
+- Full support for `gemini-3.6-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-pro-preview`, and subsequent Gemini 3 models
 - Automatic model detection for thinking level configuration
 - `mediaResolution` parameter support for multimodal inputs
 

--- a/MULTIMODAL.md
+++ b/MULTIMODAL.md
@@ -384,15 +384,15 @@ const response = await client.callTool({
 
 Multimodal support requires using a Gemini model that supports multimodal inputs. Recommended models:
 
-- `gemini-3.5-flash` (default, strong multimodal and agentic support)
+- `gemini-3.6-flash` (default, strong multimodal and agentic support)
 - `gemini-3.1-pro-preview` (high-capability reasoning and multimodal support)
-- `gemini-3.1-flash-lite` (cost-efficient multimodal support)
+- `gemini-3.5-flash-lite` (fast, cost-efficient multimodal support)
 - `gemini-2.5-pro` (stable production-ready multimodal support)
 
 Set your model in the environment:
 
 ```bash
-export GEMINI_MODEL="gemini-3.5-flash"
+export GEMINI_MODEL="gemini-3.6-flash"
 ```
 
 ## File Size Limits
@@ -417,7 +417,7 @@ export GEMINI_MODEL="gemini-3.5-flash"
 
 3. **Batch Related Queries**: Send multiple related files in one query rather than separate queries
 
-4. **Choose the Right Model**: Use models with multimodal capabilities (e.g., `gemini-3.5-flash`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`)
+4. **Choose the Right Model**: Use models with multimodal capabilities (e.g., `gemini-3.6-flash`, `gemini-3.1-pro-preview`, `gemini-3.5-flash-lite`)
 
 5. **Validate MIME Types**: Ensure you're using supported MIME types from the list above
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Inspired by OpenAI Agents SDK, the server operates as an autonomous agent:
 
 ### 🔮 Gemini 3 Model Support
 Full support for Gemini 3 generation models:
-- **gemini-3.5-flash**: Default model — fast and capable
+- **gemini-3.6-flash**: Default model — efficient agentic and multimodal workhorse
 - **gemini-3.1-pro-preview**: High-capability reasoning model
-- **gemini-3.1-flash-lite**: Cost-efficient multimodal model for high-volume workloads
+- **gemini-3.5-flash-lite**: Fast, cost-efficient multimodal model for high-volume workloads
 - **gemini-3.1-pro-preview-customtools**: Agentic endpoint optimized for custom tools
 - **thinkingLevel**: Per-query thinking budget control for Gemini 3 models
 - **GEMINI_MEDIA_RESOLUTION**: Control media quality for multimodal inputs
@@ -154,12 +154,14 @@ export GOOGLE_GENAI_USE_VERTEXAI="false"
 
 **Optional Model Settings:**
 ```bash
-export GEMINI_MODEL="gemini-3.5-flash"  # Default model
+export GEMINI_MODEL="gemini-3.6-flash"  # Default model
 export GEMINI_TEMPERATURE="1.0"
 export GEMINI_MAX_TOKENS="8192"
 export GEMINI_TOP_P="0.95"
 export GEMINI_TOP_K="40"
 ```
+
+Sampling overrides are sent only to older models that support them. Gemini 3.6 Flash and Gemini 3.5 Flash-Lite use their model defaults.
 
 **Optional Agentic Features:**
 ```bash
@@ -224,7 +226,7 @@ Add to your MCP client configuration:
       "env": {
         "GOOGLE_CLOUD_PROJECT": "your-gcp-project-id",
         "GOOGLE_CLOUD_LOCATION": "us-central1",
-        "GEMINI_MODEL": "gemini-3.5-flash",
+        "GEMINI_MODEL": "gemini-3.6-flash",
         "GEMINI_ENABLE_CONVERSATIONS": "true"
       }
     }
@@ -242,7 +244,7 @@ Add to your MCP client configuration:
       "env": {
         "GOOGLE_CLOUD_PROJECT": "your-gcp-project-id",
         "GOOGLE_CLOUD_LOCATION": "us-central1",
-        "GEMINI_MODEL": "gemini-3.5-flash"
+        "GEMINI_MODEL": "gemini-3.6-flash"
       }
     }
   }
@@ -302,7 +304,7 @@ Main agentic entrypoint that handles multi-turn execution with automatic tool se
 **Parameters:**
 - `prompt` (string, required): The text prompt to send
 - `sessionId` (string, optional): Conversation session ID
-- `model` (string, optional): Model override (e.g., `gemini-3.5-flash`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`, `gemini-3.1-pro-preview-customtools`)
+- `model` (string, optional): Model override (e.g., `gemini-3.6-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-pro-preview`, `gemini-3.1-pro-preview-customtools`)
 - `backend` (string, optional): Request backend override, `vertex` or `ai-studio` (advertised when both backends are configured)
 - `thinkingLevel` (string, optional): Gemini 3 thinking level. Options: `minimal`, `low`, `medium`, `high`
 - `mediaResolution` (string, optional): Global media resolution for multimodal inputs. Options: `low`, `medium`, `high`

--- a/examples/multimodal-usage.md
+++ b/examples/multimodal-usage.md
@@ -253,11 +253,11 @@ If you're testing with the MCP Inspector, you can send multimodal content like t
 ## Model Recommendations
 
 For best multimodal performance, use:
-- `gemini-3.5-flash` - Default with strong multimodal support
+- `gemini-3.6-flash` - Default with strong multimodal support
 - `gemini-3.1-pro-preview` - High-capability reasoning with strong multimodal support
-- `gemini-3.1-flash-lite` - Cost-efficient multimodal support
+- `gemini-3.5-flash-lite` - Fast, cost-efficient multimodal support
 
 Set in your environment:
 ```bash
-export GEMINI_MODEL="gemini-3.5-flash"
+export GEMINI_MODEL="gemini-3.6-flash"
 ```

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:mcp": "npx @modelcontextprotocol/inspector node build/index.js",
     "test:list": "echo '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\",\"params\":{}}' | node build/index.js",
     "test:query": "echo '{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"query\",\"arguments\":{\"prompt\":\"Hello\"}}}' | node build/index.js 2>&1",
-    "test:env": "node -e 'console.log(\"Project:\", process.env.GOOGLE_CLOUD_PROJECT); console.log(\"Location:\", process.env.GOOGLE_CLOUD_LOCATION); console.log(\"Model:\", process.env.GEMINI_MODEL || \"gemini-3.5-flash\")'"
+    "test:env": "node -e 'console.log(\"Project:\", process.env.GOOGLE_CLOUD_PROJECT); console.log(\"Location:\", process.env.GOOGLE_CLOUD_LOCATION); console.log(\"Model:\", process.env.GEMINI_MODEL || \"gemini-3.6-flash\")'"
   },
   "keywords": [
     "mcp",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -65,7 +65,7 @@ export function loadConfig(): GeminiAIConfig {
   const location = process.env.GOOGLE_CLOUD_LOCATION || "global";
 
   // Model and parameters - use GEMINI_* environment variables
-  const model = process.env.GEMINI_MODEL || "gemini-3.5-flash";
+  const model = process.env.GEMINI_MODEL || "gemini-3.6-flash";
   const temperature = parseFloat(process.env.GEMINI_TEMPERATURE || "1.0");
   const maxTokens = parseInt(process.env.GEMINI_MAX_TOKENS || "8192", 10);
   const topP = parseFloat(process.env.GEMINI_TOP_P || "0.95");

--- a/src/schemas/index.test.ts
+++ b/src/schemas/index.test.ts
@@ -14,15 +14,15 @@ import {
 } from './index.js';
 
 describe('QuerySchema model controls', () => {
-  it('accepts Gemini 3.1 Flash-Lite and request-level controls', () => {
+  it('accepts Gemini 3.5 Flash-Lite and request-level controls', () => {
     const parsed = QuerySchema.parse({
       prompt: 'Summarize this image',
-      model: 'gemini-3.1-flash-lite',
+      model: 'gemini-3.5-flash-lite',
       thinkingLevel: 'medium',
       mediaResolution: 'high',
     });
 
-    expect(parsed.model).toBe('gemini-3.1-flash-lite');
+    expect(parsed.model).toBe('gemini-3.5-flash-lite');
     expect(parsed.thinkingLevel).toBe('medium');
     expect(parsed.mediaResolution).toBe('high');
   });

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -55,7 +55,7 @@ const MultimodalPartSchema = z.object({
 export const QuerySchema = z.object({
   prompt: z.string().describe("The text prompt to send to the model"),
   sessionId: z.string().optional().describe("Optional conversation session ID for multi-turn conversations"),
-  model: z.string().optional().describe("Optional model override (e.g., gemini-3.5-flash, gemini-3.1-pro-preview, gemini-3.1-flash-lite, gemini-3.1-pro-preview-customtools)"),
+  model: z.string().optional().describe("Optional model override (e.g., gemini-3.6-flash, gemini-3.5-flash-lite, gemini-3.1-pro-preview, gemini-3.1-pro-preview-customtools)"),
   backend: z.enum(['vertex', 'ai-studio']).optional()
     .describe("Optional backend override ('vertex' | 'ai-studio'); defaults to the server's configured backend"),
   thinkingLevel: z.enum(['minimal', 'low', 'medium', 'high', 'MINIMAL', 'LOW', 'MEDIUM', 'HIGH']).optional()

--- a/src/server/GeminiAIMCPServer.ts
+++ b/src/server/GeminiAIMCPServer.ts
@@ -193,7 +193,7 @@ export class GeminiAIMCPServer {
               },
               model: {
                 type: "string",
-                description: "Optional model override (e.g., gemini-3.5-flash, gemini-3.1-pro-preview, gemini-3.1-flash-lite, gemini-3.1-pro-preview-customtools)",
+                description: "Optional model override (e.g., gemini-3.6-flash, gemini-3.5-flash-lite, gemini-3.1-pro-preview, gemini-3.1-pro-preview-customtools)",
               },
               thinkingLevel: {
                 type: "string",

--- a/src/services/GeminiAIService.test.ts
+++ b/src/services/GeminiAIService.test.ts
@@ -22,8 +22,8 @@ describe('isGemini3Model regex pattern', () => {
     expect(isGemini3Pattern.test('gemini-3-flash-preview')).toBe(true);
   });
 
-  it('matches gemini-3.5-flash', () => {
-    expect(isGemini3Pattern.test('gemini-3.5-flash')).toBe(true);
+  it('matches gemini-3.6-flash', () => {
+    expect(isGemini3Pattern.test('gemini-3.6-flash')).toBe(true);
   });
 
   it('matches gemini-3-pro-image', () => {
@@ -62,7 +62,7 @@ describe('ThinkingLevel enum from SDK', () => {
 });
 
 describe('default model configuration', () => {
-  it('defaults to gemini-3.5-flash', async () => {
+  it('defaults to gemini-3.6-flash', async () => {
     // Save and clear env
     const savedModel = process.env.GEMINI_MODEL;
     const savedProject = process.env.GOOGLE_CLOUD_PROJECT;
@@ -75,7 +75,7 @@ describe('default model configuration', () => {
       // Dynamic import to get fresh module
       const { loadConfig } = await import('../config/index.js');
       const config = loadConfig();
-      expect(config.model).toBe('gemini-3.5-flash');
+      expect(config.model).toBe('gemini-3.6-flash');
       expect(config.useVertexAI).toBe(true);
     } finally {
       // Restore env
@@ -93,6 +93,84 @@ describe('default model configuration', () => {
         delete process.env.GOOGLE_GENAI_USE_VERTEXAI;
       }
     }
+  });
+});
+
+describe('query sampling parameter compatibility', () => {
+  function createService(model: string) {
+    const service = new GeminiAIService({
+      projectId: 'test-project',
+      location: 'global',
+      useVertexAI: true,
+      defaultBackend: 'vertex',
+      availableBackends: ['vertex'],
+      model,
+      temperature: 0.7,
+      maxTokens: 8192,
+      topP: 0.95,
+      topK: 40,
+      enableConversations: false,
+      sessionTimeout: 3600000,
+      maxHistory: 100,
+      enableReasoning: false,
+      maxReasoningSteps: 5,
+      disableLogging: true,
+      logToStderr: false,
+      allowFileUris: false,
+    });
+    const generateContent = vi.fn().mockResolvedValue({ text: 'ok' });
+    (service as any).clientFor = () => ({ models: { generateContent } });
+    return { service, generateContent };
+  }
+
+  it.each(['gemini-3.6-flash', 'gemini-3.5-flash-lite'])(
+    'omits deprecated sampling parameters for %s',
+    async (model) => {
+      const { service, generateContent } = createService(model);
+
+      await service.query('hello');
+
+      const config = generateContent.mock.calls[0][0].config;
+      expect(config).not.toHaveProperty('temperature');
+      expect(config).not.toHaveProperty('topP');
+      expect(config).not.toHaveProperty('topK');
+      expect(config.maxOutputTokens).toBe(8192);
+    }
+  );
+
+  it('keeps supported sampling parameters for earlier models', async () => {
+    const { service, generateContent } = createService('gemini-2.5-flash');
+
+    await service.query('hello');
+
+    expect(generateContent.mock.calls[0][0].config).toMatchObject({
+      temperature: 0.7,
+      topP: 0.95,
+      topK: 40,
+      maxOutputTokens: 8192,
+    });
+  });
+
+  it('keeps temperature and topP but omits fixed topK for earlier Gemini 3 models', async () => {
+    const { service, generateContent } = createService('gemini-3.5-flash');
+
+    await service.query('hello');
+
+    const config = generateContent.mock.calls[0][0].config;
+    expect(config).toMatchObject({ temperature: 0.7, topP: 0.95, maxOutputTokens: 8192 });
+    expect(config).not.toHaveProperty('topK');
+  });
+
+  it('uses the request-level model override for sampling compatibility', async () => {
+    const { service, generateContent } = createService('gemini-2.5-flash');
+
+    await service.query('hello', { model: 'gemini-3.6-flash' });
+
+    const request = generateContent.mock.calls[0][0];
+    expect(request.model).toBe('gemini-3.6-flash');
+    expect(request.config).not.toHaveProperty('temperature');
+    expect(request.config).not.toHaveProperty('topP');
+    expect(request.config).not.toHaveProperty('topK');
   });
 });
 
@@ -255,7 +333,7 @@ describe('generateVideo backend compatibility', () => {
       location: 'us-central1',
       apiKey: 'test-api-key',
       useVertexAI: true,
-      model: 'gemini-3.5-flash',
+      model: 'gemini-3.6-flash',
       temperature: 0.7,
       maxTokens: 8192,
       topP: 0.95,
@@ -397,7 +475,7 @@ describe('generateOmniVideo (Interactions API)', () => {
       useVertexAI: false,
       defaultBackend: 'ai-studio',
       availableBackends: ['ai-studio'],
-      model: 'gemini-3.5-flash',
+      model: 'gemini-3.6-flash',
       temperature: 0.7,
       maxTokens: 8192,
       topP: 0.95,
@@ -512,7 +590,7 @@ describe('referenceSearch (Google Search grounding)', () => {
       location: 'us-central1',
       apiKey: 'test-api-key',
       useVertexAI: true,
-      model: 'gemini-3.5-flash',
+      model: 'gemini-3.6-flash',
       temperature: 0.7,
       maxTokens: 8192,
       topP: 0.95,
@@ -569,6 +647,7 @@ describe('referenceSearch (Google Search grounding)', () => {
 
     const params = generateContent.mock.calls[0][0];
     const googleSearch = params.config.tools[0].googleSearch;
+    expect(params.config).not.toHaveProperty('temperature');
     expect(googleSearch.excludeDomains).toEqual(['reddit.com']);
     expect(googleSearch.blockingConfidence).toBe('BLOCK_MEDIUM_AND_ABOVE');
     expect(googleSearch.searchTypes).toEqual({ webSearch: {}, imageSearch: {} });

--- a/src/services/GeminiAIService.ts
+++ b/src/services/GeminiAIService.ts
@@ -236,6 +236,26 @@ export class GeminiAIService {
   }
 
   /**
+   * Gemini 3.6 Flash, 3.5 Flash-Lite, and later model generations ignore
+   * sampling overrides and may reject them in future API revisions.
+   */
+  private supportsSamplingParameters(modelOverride?: string): boolean {
+    const model = (modelOverride || this.config.model).toLowerCase();
+    if (/^gemini[-_]?3\.5-flash-lite(?:-|$)/.test(model)) {
+      return false;
+    }
+
+    const version = model.match(/^gemini[-_]?(\d+)(?:\.(\d+))?/);
+    if (!version) {
+      return true;
+    }
+
+    const major = Number(version[1]);
+    const minor = Number(version[2] || 0);
+    return major < 3 || (major === 3 && minor < 6);
+  }
+
+  /**
    * Query Gemini with a prompt and optional multimodal content
    */
   async query(
@@ -247,15 +267,18 @@ export class GeminiAIService {
       const effectiveModel = options.model || this.config.model;
 
       const config: GenerateContentConfig = {
-        temperature: this.config.temperature,
         maxOutputTokens: this.config.maxTokens,
-        topP: this.config.topP,
       };
 
-      // Gemini 3 exposes topK as a fixed model default. Sending a custom value
-      // can be rejected by newer model endpoints, so only send it to older models.
-      if (!this.isGemini3Model(effectiveModel)) {
-        config.topK = this.config.topK;
+      if (this.supportsSamplingParameters(effectiveModel)) {
+        config.temperature = this.config.temperature;
+        config.topP = this.config.topP;
+
+        // Gemini 3 exposes topK as a fixed model default. Sending a custom value
+        // can be rejected by newer model endpoints, so only send it to older models.
+        if (!this.isGemini3Model(effectiveModel)) {
+          config.topK = this.config.topK;
+        }
       }
 
       const mediaResolution = this.resolveMediaResolution(
@@ -1030,10 +1053,12 @@ export class GeminiAIService {
     }
 
     const config: GenerateContentConfig = {
-      temperature: this.config.temperature,
       maxOutputTokens: this.config.maxTokens,
       tools,
     };
+    if (this.supportsSamplingParameters(model)) {
+      config.temperature = this.config.temperature;
+    }
     if (options.systemInstruction) {
       config.systemInstruction = options.systemInstruction;
     }


### PR DESCRIPTION
## Summary

- change the default query model from `gemini-3.5-flash` to `gemini-3.6-flash`
- update the recommended low-cost model to `gemini-3.5-flash-lite`
- omit deprecated `temperature`, `topP`, and `topK` overrides for Gemini 3.6 Flash, Gemini 3.5 Flash-Lite, and later generations while preserving legacy model behavior
- refresh MCP schema descriptions, examples, environment defaults, and model compatibility documentation
- add regression coverage for default selection, per-request overrides, and sampling parameter compatibility

## Why

Google released Gemini 3.6 Flash and Gemini 3.5 Flash-Lite as GA models. These model generations no longer support custom sampling parameter values, so forwarding the server's legacy defaults would be ignored now and may fail on future model endpoints.

## Impact

New installations use `gemini-3.6-flash` by default. Existing users who explicitly set `GEMINI_MODEL` keep their selected model. Sampling environment variables continue to apply to older models that support them and are omitted for the new models.

Gemini 3.5 Flash Cyber is not exposed because it is a limited-access pilot. `gemini-3.1-pro-preview-customtools` remains documented because it is a real Preview endpoint for custom-tool-heavy agentic workflows.

## Validation

- `npm run build`
- `GOOGLE_CLOUD_PROJECT=test-project npm run test:list`
- `npm run test:env`
- compiled smoke checks for the default model and `QuerySchema`
- compiled smoke checks for `query` and `reference_search` sampling parameter compatibility across 3.6 Flash, 3.5 Flash-Lite, 3.5 Flash, and 2.5 Flash
- `git diff --check`

The repository does not currently declare a Vitest dependency or test script, so the existing Vitest files were not executed. No live Gemini API request was made.

## References

- https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-6-flash-3-5-flash-lite-3-5-flash-cyber/
- https://ai.google.dev/gemini-api/docs/generate-content/latest-model
